### PR TITLE
:globe_with_meridians: Move custom domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,10 @@ jobs:
         run: |
           REPO_NAME="${GITHUB_REPOSITORY#*/}"
           OWNER_NAME="${GITHUB_REPOSITORY_OWNER}"
-          if [ "${REPO_NAME}" = "${OWNER_NAME}.github.io" ]; then
+          # A custom domain (CNAME file) serves from the domain root, not /<repo>/.
+          if [ -s public/CNAME ]; then
+            echo "BASE_PATH=/" >> "$GITHUB_ENV"
+          elif [ "${REPO_NAME}" = "${OWNER_NAME}.github.io" ]; then
             echo "BASE_PATH=/" >> "$GITHUB_ENV"
           else
             echo "BASE_PATH=/${REPO_NAME}/" >> "$GITHUB_ENV"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ issues.
 
 **Ecosystem context:** this site is the discovery layer in a five-site rope
 ecosystem run through Peg Productions BV (Tsuri Neko). CNAME is
-`international-events.tsurineko.org`; the repo lives under the `tsurineko.org`
+`shibari-events.tsurineko.org`; the repo lives under the `tsurineko.org`
 subdomain family. Siblings:
 
 - `tsurineko.org` — main content (teaching, jams, classes)

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-international-events.tsurineko.org
+shibari-events.tsurineko.org

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,9 +7,9 @@
         </RouterLink>
         <a
           class="rounded-xl border border-[var(--color-secondary)] bg-[var(--color-surface-strong)] px-3 py-1 text-sm text-[var(--color-secondary)] transition hover:-translate-y-0.5 hover:bg-[var(--color-secondary)] hover:text-[var(--color-surface-strong)]"
-          href="https://international-events.tsurineko.org"
+          href="https://shibari-events.tsurineko.org"
         >
-          international-events.tsurineko.org
+          shibari-events.tsurineko.org
         </a>
       </div>
     </header>


### PR DESCRIPTION
"international-events.tsurineko.org" was generic enough to read like it belonged to Tsuri Neko rather than the wider rope-scene directory this site is positioned as. "shibari-events" puts the discipline name in the subdomain so newcomers who googled their first event get an unambiguous signal, and the category prefix reads as "a directory" not "Tsuri Neko's own calendar."

Also fixes a latent deploy bug: the workflow computed BASE_PATH from the repo name ("/international-shibari-events/"), which works on the default ropelabsorg.github.io/international-shibari-events/ URL but 404s every asset the moment a custom domain serves the site from root. Added a third branch that checks for a non-empty public/CNAME and falls back to BASE_PATH=/ — matches how GitHub Pages itself routes custom-domain requests.

Verified locally: BASE_PATH=/ npm run build produces dist/index.html with src="/assets/index-*.js" (root-relative), not /international-shibari-events/assets/*. The workflow's file-test (-s public/CNAME) takes the custom-domain branch for this repo, keeps the {owner}.github.io branch unchanged, and keeps the repo-name fallback for forks or default-Pages-URL deployments.

DNS side (separate from this commit): the tsurineko.org zone needs a CNAME record shibari-events -> ropelabsorg.github.io (DNS-only if the zone is behind Cloudflare — proxied mode breaks GitHub's cert validation handshake). GitHub will re-validate and provision the Let's Encrypt cert once the CNAME is reachable.

<!-- Thanks for contributing! A short description of the change helps review. -->

## What's changing

<!-- One or two sentences. -->

## Checklist

- [ ] `npm run validate:data` passes
- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] If predictions logic changed: `npm run backtest` run and reviewed (see CONTRIBUTING.md)
- [ ] If event data changed: `lastUpdated` bumped
- [ ] If a slug changed or a new event was added: `data/slug-history.jsonc` appended (see CONTRIBUTING.md — slugs are load-bearing for user-facing watchlists)
