### PR TITLE
chore: add conductor.json with mise trust setup script

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "setup": "mise trust"
+  }
+}


### PR DESCRIPTION
Conductor runs the setup script on workspace creation. Running `mise trust` eliminates the mise config trust errors that appear in every new workspace.

<!-- Thanks for contributing! A short description of the change helps review. -->

## What's changing

<!-- One or two sentences. -->

## Checklist

- [ ] `npm run validate:data` passes
- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] If predictions logic changed: `npm run backtest` run and reviewed (see CONTRIBUTING.md)
- [ ] If event data changed: `lastUpdated` bumped
- [ ] If a slug changed or a new event was added: `data/slug-history.jsonc` appended (see CONTRIBUTING.md — slugs are load-bearing for user-facing watchlists)
