### PR TITLE
Discovery lane: Watchlist, filters, confidence badges, ticket watch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ Thumbs.db
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
+.gstack/

--- a/TODOS.md
+++ b/TODOS.md
@@ -17,3 +17,36 @@ Items deferred from planning sessions. Add context, not just titles — future-y
 **Context:** v1 of the reminder backend ships with a `mailto:` button on each event page. The form fields (`ticketSaleDate`, `sourceUrl`, `notes` capped at 500 chars) are already scoped. Upgrade path is to replace the client-side mailto constructor with `POST /api/share-ticket-date` that sends the same structured email server-side.
 
 **Depends on / blocked by:** v1 Worker + Turnstile setup must land first. After that, this is ~2 hours of work.
+
+---
+
+## Confidence classifier thresholds: rebase on edition count or keep on interval count?
+
+**What:** `classifyConfidence(sampleSize)` in `src/lib/predictions.ts` uses *intervals* (`historicalEditions.length - 1`), so 3 editions → sampleSize 2 → "medium" and 4 editions → "high". Decide if that's the right story for contributors/users or if it should rebase on edition count directly.
+
+**Why:** Adversarial review flagged that a contributor looking at an event with 3 past editions would intuitively expect "high confidence" — they'd see 3 years of data. Statistically the interval count is the honest signal (you need ≥2 intervals before the median does anything meaningful), but the label "Estimated · Medium" on an event with 3 historical years reads as unconfident.
+
+**Options:**
+- A) Keep as-is, add a one-line note to `CONTRIBUTING.md` explaining the classifier counts intervals not editions.
+- B) Rebase thresholds on `historicalEditions.length`: `≥3 → high`, `≥2 → medium`, else low. Matches user intuition; slightly less rigorous but still monotonic.
+
+**Context:** Landed in commit 30f6675. Tests in `tests/confidence.spec.ts` would need to update if we pick B.
+
+---
+
+## WatchlistPage UX for retired/missing slugs
+
+**What:** If a watched slug isn't in the directory (because its event got retired per the slug ledger, or the data file was deleted), `WatchlistPage.vue` silently filters it out and shows a `"{N} watched events are no longer in the directory"` line with no names and no unwatch button. User can't clean up their list.
+
+**Why:** Slug ledger (`data/slug-history.jsonc`) should prevent this in practice — retired slugs stay in the ledger and get moved to `retired`, but the event file goes away. Right now the user's watchlist points at a dead slug with no display affordance.
+
+**Pros of fixing:** Respects the slug-immutability invariant the ledger enforces. Gives users a way to unwatch orphaned slugs without devtools + `localStorage.removeItem`.
+
+**Cons:** The directory doesn't currently retire anything. We may never hit this in practice. Can wait for the first real retirement.
+
+**Options:**
+- A) Persist `{slug, displayName, savedAt}` triples instead of bare slugs, so orphaned entries can be shown by name with a per-row unwatch.
+- B) Keep slugs only but surface the raw slug in the "no longer in directory" banner with a "Clean up N orphaned slugs" button.
+- C) Defer until the first event is actually retired (YAGNI).
+
+**Context:** Flagged by Codex adversarial + Claude adversarial during /ship review of PR (watchlist branch). Both rated medium severity / low-frequency.

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,16 +1,44 @@
+<script setup lang="ts">
+import { useWatchlist } from "./lib/watchlist";
+
+const { count: watchCount } = useWatchlist();
+</script>
+
 <template>
   <div class="min-h-screen bg-[var(--color-page)] text-[var(--color-text)]">
     <header class="border-b border-[var(--color-border)] bg-white/70 backdrop-blur">
-      <div class="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4">
+      <div class="mx-auto flex w-full max-w-6xl items-center justify-between gap-3 px-4 py-4">
         <RouterLink class="text-lg font-semibold tracking-wide text-[var(--color-secondary)]" to="/">
           International Shibari Events
         </RouterLink>
-        <a
-          class="rounded-xl border border-[var(--color-secondary)] bg-[var(--color-surface-strong)] px-3 py-1 text-sm text-[var(--color-secondary)] transition hover:-translate-y-0.5 hover:bg-[var(--color-secondary)] hover:text-[var(--color-surface-strong)]"
-          href="https://shibari-events.tsurineko.org"
-        >
-          shibari-events.tsurineko.org
-        </a>
+        <nav class="flex items-center gap-2">
+          <RouterLink
+            to="/watchlist"
+            class="inline-flex items-center gap-1.5 rounded-xl border border-[var(--color-primary)] bg-[var(--color-surface-strong)] px-3 py-1 text-sm font-medium text-[var(--color-primary)] transition hover:bg-[var(--color-primary)] hover:text-[var(--color-surface-strong)]"
+            active-class="bg-[var(--color-primary)] text-[var(--color-surface-strong)]"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="h-4 w-4"
+              aria-hidden="true"
+            >
+              <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+            </svg>
+            <span>Watchlist<span v-if="watchCount > 0"> ({{ watchCount }})</span></span>
+          </RouterLink>
+          <a
+            class="hidden rounded-xl border border-[var(--color-secondary)] bg-[var(--color-surface-strong)] px-3 py-1 text-sm text-[var(--color-secondary)] transition hover:-translate-y-0.5 hover:bg-[var(--color-secondary)] hover:text-[var(--color-surface-strong)] sm:inline-flex"
+            href="https://shibari-events.tsurineko.org"
+          >
+            shibari-events.tsurineko.org
+          </a>
+        </nav>
       </div>
     </header>
     <main class="mx-auto w-full max-w-6xl px-4 py-8">

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,13 @@ const { count: watchCount } = useWatchlist();
         </RouterLink>
         <nav class="flex items-center gap-2">
           <RouterLink
+            to="/tickets"
+            class="inline-flex items-center gap-1.5 rounded-xl border border-[var(--color-secondary)] bg-[var(--color-surface-strong)] px-3 py-1 text-sm font-medium text-[var(--color-secondary)] transition hover:bg-[var(--color-secondary)] hover:text-[var(--color-surface-strong)]"
+            active-class="bg-[var(--color-secondary)] text-[var(--color-surface-strong)]"
+          >
+            Tickets
+          </RouterLink>
+          <RouterLink
             to="/watchlist"
             class="inline-flex items-center gap-1.5 rounded-xl border border-[var(--color-primary)] bg-[var(--color-surface-strong)] px-3 py-1 text-sm font-medium text-[var(--color-primary)] transition hover:bg-[var(--color-primary)] hover:text-[var(--color-surface-strong)]"
             active-class="bg-[var(--color-primary)] text-[var(--color-surface-strong)]"

--- a/src/components/DateField.vue
+++ b/src/components/DateField.vue
@@ -1,14 +1,22 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { formatDisplayDate } from "../lib/events";
+import { confidenceAriaLabel, formatDisplayDate, formatEstimatedLabel } from "../lib/events";
+import type { TConfidenceLevel } from "../lib/predictions";
 
 const props = defineProps<{
   label: string;
   value: Date | null;
   isEstimated: boolean;
+  confidence?: TConfidenceLevel;
 }>();
 
 const formattedDate = computed(() => formatDisplayDate(props.value));
+const badgeText = computed(() =>
+  props.confidence ? formatEstimatedLabel(props.confidence) : "Estimated",
+);
+const badgeAriaLabel = computed(() =>
+  props.confidence ? confidenceAriaLabel(props.confidence) : "Estimated date",
+);
 </script>
 
 <template>
@@ -18,8 +26,12 @@ const formattedDate = computed(() => formatDisplayDate(props.value));
     </p>
     <p class="mt-1 text-sm font-medium text-[var(--color-text)]">
       {{ formattedDate }}
-      <span v-if="isEstimated" class="ml-2 rounded-full bg-[rgba(44,74,107,0.10)] px-2 py-0.5 text-xs font-medium text-[var(--color-secondary)]">
-        Estimated
+      <span
+        v-if="isEstimated"
+        class="ml-2 rounded-full bg-[rgba(44,74,107,0.10)] px-2 py-0.5 text-xs font-medium text-[var(--color-secondary)]"
+        :aria-label="badgeAriaLabel"
+      >
+        {{ badgeText }}
       </span>
     </p>
   </div>

--- a/src/components/EventCard.vue
+++ b/src/components/EventCard.vue
@@ -4,7 +4,7 @@ import { useRouter } from "vue-router";
 import StatusPill from "./StatusPill.vue";
 import ObfuscatedEmail from "./ObfuscatedEmail.vue";
 import WatchButton from "./WatchButton.vue";
-import { formatDateRange } from "../lib/events";
+import { confidenceAriaLabel, formatDateRange, formatEstimatedLabel } from "../lib/events";
 import type { IEventSummary } from "../lib/events";
 
 const props = defineProps<{
@@ -59,8 +59,12 @@ async function openEventDetails(): Promise<void> {
         </p>
         <p class="mt-1 text-sm font-medium text-[var(--color-text)]">
           {{ dateRange }}
-          <span v-if="summary.nextDate.isEstimated" class="ml-2 rounded-full bg-[rgba(44,74,107,0.10)] px-2 py-0.5 text-xs font-medium text-[var(--color-secondary)]">
-            Estimated
+          <span
+            v-if="summary.nextDate.isEstimated"
+            class="ml-2 rounded-full bg-[rgba(44,74,107,0.10)] px-2 py-0.5 text-xs font-medium text-[var(--color-secondary)]"
+            :aria-label="confidenceAriaLabel(summary.confidence)"
+          >
+            {{ formatEstimatedLabel(summary.confidence) }}
           </span>
         </p>
       </div>
@@ -70,8 +74,12 @@ async function openEventDetails(): Promise<void> {
         </p>
         <p class="mt-1 text-sm font-medium text-[var(--color-text)]">
           {{ summary.ticketDate.value ? summary.ticketDate.value.toISOString().slice(0, 10) : "TBA" }}
-          <span v-if="summary.ticketDate.isEstimated" class="ml-2 rounded-full bg-[rgba(44,74,107,0.10)] px-2 py-0.5 text-xs font-medium text-[var(--color-secondary)]">
-            Estimated
+          <span
+            v-if="summary.ticketDate.isEstimated"
+            class="ml-2 rounded-full bg-[rgba(44,74,107,0.10)] px-2 py-0.5 text-xs font-medium text-[var(--color-secondary)]"
+            :aria-label="confidenceAriaLabel(summary.confidence)"
+          >
+            {{ formatEstimatedLabel(summary.confidence) }}
           </span>
         </p>
       </div>

--- a/src/components/EventCard.vue
+++ b/src/components/EventCard.vue
@@ -3,6 +3,7 @@ import { computed } from "vue";
 import { useRouter } from "vue-router";
 import StatusPill from "./StatusPill.vue";
 import ObfuscatedEmail from "./ObfuscatedEmail.vue";
+import WatchButton from "./WatchButton.vue";
 import { formatDateRange } from "../lib/events";
 import type { IEventSummary } from "../lib/events";
 
@@ -77,6 +78,7 @@ async function openEventDetails(): Promise<void> {
     </div>
 
     <div class="mt-4 flex flex-wrap gap-2 text-sm">
+      <WatchButton :slug="event.slug" />
       <a
         v-if="event.links.website"
         :href="event.links.website"

--- a/src/components/WatchButton.vue
+++ b/src/components/WatchButton.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useWatchlist } from "../lib/watchlist";
+
+const props = defineProps<{
+  slug: string;
+  size?: "sm" | "md";
+}>();
+
+const size = computed(() => props.size ?? "sm");
+const { isWatching, toggle } = useWatchlist();
+const watching = computed(() => isWatching(props.slug));
+
+const label = computed(() => (watching.value ? "Watching" : "Watch"));
+const ariaLabel = computed(() =>
+  watching.value ? `Stop watching this event` : `Watch this event`,
+);
+
+function handleClick(): void {
+  toggle(props.slug);
+}
+</script>
+
+<template>
+  <button
+    type="button"
+    :aria-pressed="watching"
+    :aria-label="ariaLabel"
+    :title="watching ? 'Remove from watchlist' : 'Save to your watchlist (stored in this browser)'"
+    :class="[
+      'inline-flex items-center gap-1.5 rounded-xl border font-medium transition',
+      size === 'sm' ? 'px-3 py-1 text-sm' : 'px-4 py-2 text-base',
+      watching
+        ? 'border-[var(--color-primary)] bg-[var(--color-primary)] text-[var(--color-surface-strong)] hover:bg-[var(--color-primary-hover)] hover:border-[var(--color-primary-hover)]'
+        : 'border-[var(--color-primary)] bg-[var(--color-surface-strong)] text-[var(--color-primary)] hover:bg-[var(--color-primary)] hover:text-[var(--color-surface-strong)]',
+    ]"
+    @click.stop="handleClick"
+    @keydown.enter.stop
+    @keydown.space.stop
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      :fill="watching ? 'currentColor' : 'none'"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class="h-4 w-4"
+      aria-hidden="true"
+    >
+      <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+    </svg>
+    {{ label }}
+  </button>
+</template>

--- a/src/components/WatchButton.vue
+++ b/src/components/WatchButton.vue
@@ -35,8 +35,6 @@ function handleClick(): void {
         : 'border-[var(--color-primary)] bg-[var(--color-surface-strong)] text-[var(--color-primary)] hover:bg-[var(--color-primary)] hover:text-[var(--color-surface-strong)]',
     ]"
     @click.stop="handleClick"
-    @keydown.enter.stop
-    @keydown.space.stop
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,7 +1,13 @@
 import { parse as parseJsonc } from "jsonc-parser";
 import type { IEventData, TStatus } from "../../schemas/event.schema";
-import { addDays, deriveNextEditionDates, getCadenceAndDuration, parseIsoDate } from "./predictions";
-import type { IPredictionInfo } from "./predictions";
+import {
+  addDays,
+  classifyConfidence,
+  deriveNextEditionDates,
+  getCadenceAndDuration,
+  parseIsoDate,
+} from "./predictions";
+import type { IPredictionInfo, TConfidenceLevel } from "./predictions";
 
 export type TTemporalState = "happening_now" | "upcoming" | "ended";
 export type TSortKey = "eventDate" | "ticketDate" | "status" | "lastUpdated" | "name";
@@ -18,6 +24,21 @@ export interface IEventSummary {
   endDate: IResolvedDate;
   ticketDate: IResolvedDate;
   temporalState: TTemporalState;
+  confidence: TConfidenceLevel;
+}
+
+const confidenceLabels: Record<TConfidenceLevel, string> = {
+  high: "High confidence",
+  medium: "Medium confidence",
+  low: "Low confidence",
+};
+
+export function formatEstimatedLabel(confidence: TConfidenceLevel): string {
+  return `Estimated · ${confidence.charAt(0).toUpperCase()}${confidence.slice(1)}`;
+}
+
+export function confidenceAriaLabel(confidence: TConfidenceLevel): string {
+  return confidenceLabels[confidence];
 }
 
 export interface IEditionDisplay {
@@ -133,6 +154,7 @@ export function getEventSummaries(eventDataList: IEventData[], nowDate = new Dat
   return eventDataList.map((eventData) => {
     const nextEdition = eventData.nextEdition;
     const derivedDates = deriveNextEditionDates(eventData);
+    const prediction = getCadenceAndDuration(eventData);
     const nextDate = resolveDate(parseIsoDate(nextEdition.startDate), derivedDates.startDate);
     const ticketDate = resolveDate(parseIsoDate(nextEdition.ticketSaleDate), derivedDates.ticketDate);
     const endDate = resolveDate(parseIsoDate(nextEdition.endDate), derivedDates.endDate);
@@ -143,6 +165,7 @@ export function getEventSummaries(eventDataList: IEventData[], nowDate = new Dat
       endDate,
       ticketDate,
       temporalState: inferTemporalState(nextDate.value, endDate.value, nowDate),
+      confidence: classifyConfidence(prediction.sampleSize),
     };
   });
 }

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -147,6 +147,79 @@ export function getEventSummaries(eventDataList: IEventData[], nowDate = new Dat
   });
 }
 
+export interface IEventFilters {
+  country: string | null;
+  month: string | null;
+  status: TStatus | null;
+}
+
+export const EMPTY_FILTERS: IEventFilters = {
+  country: null,
+  month: null,
+  status: null,
+};
+
+function toYearMonth(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
+}
+
+export function filterEventSummaries(
+  eventSummaries: IEventSummary[],
+  filters: IEventFilters,
+): IEventSummary[] {
+  return eventSummaries.filter((summary) => {
+    if (filters.country && summary.event.location.country !== filters.country) {
+      return false;
+    }
+    if (filters.status && summary.event.status !== filters.status) {
+      return false;
+    }
+    if (filters.month) {
+      if (!summary.nextDate.value) return false;
+      if (toYearMonth(summary.nextDate.value) !== filters.month) return false;
+    }
+    return true;
+  });
+}
+
+export function countActiveFilters(filters: IEventFilters): number {
+  return (filters.country ? 1 : 0) + (filters.month ? 1 : 0) + (filters.status ? 1 : 0);
+}
+
+export function extractCountryOptions(eventSummaries: IEventSummary[]): string[] {
+  const countries = new Set<string>();
+  for (const summary of eventSummaries) {
+    if (summary.event.location.country) countries.add(summary.event.location.country);
+  }
+  return [...countries].sort((a, b) => a.localeCompare(b));
+}
+
+export function extractMonthOptions(eventSummaries: IEventSummary[]): Array<{ value: string; label: string }> {
+  const months = new Set<string>();
+  for (const summary of eventSummaries) {
+    if (summary.nextDate.value) months.add(toYearMonth(summary.nextDate.value));
+  }
+  const formatter = new Intl.DateTimeFormat("en-GB", { month: "short", year: "numeric" });
+  return [...months]
+    .sort()
+    .map((yearMonth) => {
+      const [year, month] = yearMonth.split("-").map(Number);
+      const date = new Date(Date.UTC(year, month - 1, 1));
+      return { value: yearMonth, label: formatter.format(date) };
+    });
+}
+
+export function extractStatusOptions(eventSummaries: IEventSummary[]): TStatus[] {
+  const statuses = new Set<TStatus>();
+  for (const summary of eventSummaries) {
+    statuses.add(summary.event.status);
+  }
+  const ordered: TStatus[] = ["on_sale", "waiting_list", "scheduled", "sold_out", "tba"];
+  return ordered.filter((status) => statuses.has(status));
+}
+
 export function sortEventSummaries(eventSummaries: IEventSummary[], sortKey: TSortKey): IEventSummary[] {
   const sorted = [...eventSummaries];
 

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -95,8 +95,13 @@ function inferTemporalState(startDate: Date | null, endDate: Date | null, nowDat
     return "upcoming";
   }
 
+  // Event dates are stored as YYYY-MM-DD (parsed as midnight UTC). To treat an event as
+  // "still happening" for its full final calendar day, compare against the end of that day
+  // rather than its midnight-UTC start. Without this, a May 4 event is classified as ended
+  // at 00:00 UTC on May 4 — users on the Tickets page lose access on the day they're running.
   const resolvedEndDate = endDate || startDate;
-  if (startDate <= nowDate && resolvedEndDate >= nowDate) {
+  const endOfLastDay = new Date(resolvedEndDate.getTime() + 24 * 60 * 60 * 1000 - 1);
+  if (startDate <= nowDate && endOfLastDay >= nowDate) {
     return "happening_now";
   }
 
@@ -183,8 +188,12 @@ export const EMPTY_FILTERS: IEventFilters = {
 };
 
 function toYearMonth(date: Date): string {
-  const year = date.getUTCFullYear();
-  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  // Use local time so the bucket matches what formatDisplayDate renders. Event dates are
+  // stored as YYYY-MM-DD at 00:00:00Z; formatting them via Intl.DateTimeFormat in a
+  // negative-UTC-offset zone (US, LATAM) shifts the display to the prior day's month,
+  // so UTC-based bucketing would mislabel the event's month in the filter dropdown.
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
   return `${year}-${month}`;
 }
 
@@ -229,7 +238,8 @@ export function extractMonthOptions(eventSummaries: IEventSummary[]): Array<{ va
     .sort()
     .map((yearMonth) => {
       const [year, month] = yearMonth.split("-").map(Number);
-      const date = new Date(Date.UTC(year, month - 1, 1));
+      // Local-time constructor keeps the label in sync with toYearMonth (which is also local).
+      const date = new Date(year, month - 1, 1);
       return { value: yearMonth, label: formatter.format(date) };
     });
 }

--- a/src/lib/predictions.ts
+++ b/src/lib/predictions.ts
@@ -15,6 +15,14 @@ export interface IPredictionInfo {
   sourceNotes: string[];
 }
 
+export type TConfidenceLevel = "high" | "medium" | "low";
+
+export function classifyConfidence(sampleSize: number): TConfidenceLevel {
+  if (sampleSize >= 3) return "high";
+  if (sampleSize >= 1) return "medium";
+  return "low";
+}
+
 export interface IDerivedNextEditionDates {
   startDate: Date | null;
   endDate: Date | null;

--- a/src/lib/watchlist.ts
+++ b/src/lib/watchlist.ts
@@ -12,10 +12,12 @@ export interface IWatchlist {
 }
 
 function readFromStorage(): Set<string> {
-  if (typeof localStorage === "undefined") return new Set();
-  const raw = localStorage.getItem(STORAGE_KEY);
-  if (!raw) return new Set();
+  // Safari private mode + strict-privacy settings can throw SecurityError on getItem.
+  // Must swallow here — this runs at module import, so any throw white-screens the SPA.
   try {
+    if (typeof localStorage === "undefined") return new Set();
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return new Set();
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) return new Set();
     return new Set(parsed.filter((value): value is string => typeof value === "string"));
@@ -25,8 +27,15 @@ function readFromStorage(): Set<string> {
 }
 
 function writeToStorage(slugs: ReadonlySet<string>): void {
-  if (typeof localStorage === "undefined") return;
-  localStorage.setItem(STORAGE_KEY, JSON.stringify([...slugs].sort()));
+  // QuotaExceededError + Safari private-mode SecurityError both throw here.
+  // Failing silently is preferable to crashing a click handler; the in-memory ref
+  // stays authoritative for the session, and the next reload will re-read (may be empty).
+  try {
+    if (typeof localStorage === "undefined") return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...slugs].sort()));
+  } catch {
+    // Best-effort. User still sees reactive updates; persistence just doesn't stick.
+  }
 }
 
 const watchedSlugs = ref<ReadonlySet<string>>(readFromStorage());
@@ -46,16 +55,25 @@ function isWatching(slug: string): boolean {
 }
 
 function watch(slug: string): void {
-  if (watchedSlugs.value.has(slug)) return;
-  const next = new Set(watchedSlugs.value);
+  // Read-modify-write against localStorage, not the in-memory ref. Prevents a cross-tab
+  // race where Tab B's handler runs before its storage-event listener has absorbed Tab A's
+  // concurrent write — otherwise B would clobber A's change.
+  const next = new Set(readFromStorage());
+  if (next.has(slug)) {
+    watchedSlugs.value = next;
+    return;
+  }
   next.add(slug);
   watchedSlugs.value = next;
   writeToStorage(next);
 }
 
 function unwatch(slug: string): void {
-  if (!watchedSlugs.value.has(slug)) return;
-  const next = new Set(watchedSlugs.value);
+  const next = new Set(readFromStorage());
+  if (!next.has(slug)) {
+    watchedSlugs.value = next;
+    return;
+  }
   next.delete(slug);
   watchedSlugs.value = next;
   writeToStorage(next);

--- a/src/lib/watchlist.ts
+++ b/src/lib/watchlist.ts
@@ -1,0 +1,81 @@
+import { ref, computed, type ComputedRef, type Ref } from "vue";
+
+const STORAGE_KEY = "shibari-events.watchlist.v1";
+
+export interface IWatchlist {
+  watchedSlugs: Ref<ReadonlySet<string>>;
+  count: ComputedRef<number>;
+  isWatching: (slug: string) => boolean;
+  watch: (slug: string) => void;
+  unwatch: (slug: string) => void;
+  toggle: (slug: string) => void;
+}
+
+function readFromStorage(): Set<string> {
+  if (typeof localStorage === "undefined") return new Set();
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return new Set();
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((value): value is string => typeof value === "string"));
+  } catch {
+    return new Set();
+  }
+}
+
+function writeToStorage(slugs: ReadonlySet<string>): void {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify([...slugs].sort()));
+}
+
+const watchedSlugs = ref<ReadonlySet<string>>(readFromStorage());
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key === STORAGE_KEY) {
+      watchedSlugs.value = readFromStorage();
+    }
+  });
+}
+
+const count = computed(() => watchedSlugs.value.size);
+
+function isWatching(slug: string): boolean {
+  return watchedSlugs.value.has(slug);
+}
+
+function watch(slug: string): void {
+  if (watchedSlugs.value.has(slug)) return;
+  const next = new Set(watchedSlugs.value);
+  next.add(slug);
+  watchedSlugs.value = next;
+  writeToStorage(next);
+}
+
+function unwatch(slug: string): void {
+  if (!watchedSlugs.value.has(slug)) return;
+  const next = new Set(watchedSlugs.value);
+  next.delete(slug);
+  watchedSlugs.value = next;
+  writeToStorage(next);
+}
+
+function toggle(slug: string): void {
+  if (watchedSlugs.value.has(slug)) {
+    unwatch(slug);
+  } else {
+    watch(slug);
+  }
+}
+
+export function useWatchlist(): IWatchlist {
+  return { watchedSlugs, count, isWatching, watch, unwatch, toggle };
+}
+
+export function _resetWatchlistForTests(): void {
+  watchedSlugs.value = new Set();
+  if (typeof localStorage !== "undefined") {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}

--- a/src/pages/EventPage.vue
+++ b/src/pages/EventPage.vue
@@ -4,6 +4,7 @@ import { useRoute } from "vue-router";
 import DateField from "../components/DateField.vue";
 import ObfuscatedEmail from "../components/ObfuscatedEmail.vue";
 import StatusPill from "../components/StatusPill.vue";
+import WatchButton from "../components/WatchButton.vue";
 import { buildEditionDisplays, formatDateRange, getEventSummaries, loadEventsData } from "../lib/events";
 
 const route = useRoute();
@@ -44,7 +45,10 @@ const temporalStateLabelMap: Record<string, string> = {
         <h1 class="text-3xl font-bold text-[var(--color-secondary)]">
           {{ event.name }}
         </h1>
-        <StatusPill :status="event.status" />
+        <div class="flex items-center gap-3">
+          <WatchButton :slug="event.slug" size="md" />
+          <StatusPill :status="event.status" />
+        </div>
       </div>
       <p class="mt-2 text-[var(--color-text)]">
         {{ event.location.venue }} · {{ event.location.city }}, {{ event.location.country }}

--- a/src/pages/EventPage.vue
+++ b/src/pages/EventPage.vue
@@ -6,6 +6,7 @@ import ObfuscatedEmail from "../components/ObfuscatedEmail.vue";
 import StatusPill from "../components/StatusPill.vue";
 import WatchButton from "../components/WatchButton.vue";
 import { buildEditionDisplays, formatDateRange, getEventSummaries, loadEventsData } from "../lib/events";
+import { classifyConfidence, getCadenceAndDuration } from "../lib/predictions";
 
 const route = useRoute();
 const events = loadEventsData();
@@ -20,6 +21,9 @@ const event = computed(() => {
 });
 
 const editionData = computed(() => (event.value ? buildEditionDisplays(event.value) : null));
+const eventConfidence = computed(() =>
+  event.value ? classifyConfidence(getCadenceAndDuration(event.value).sampleSize) : "low",
+);
 const temporalState = computed(() => {
   if (!event.value) {
     return "upcoming";
@@ -79,16 +83,19 @@ const temporalStateLabelMap: Record<string, string> = {
             label="Event dates"
             :value="edition.startDate.value"
             :is-estimated="edition.startDate.isEstimated"
+            :confidence="eventConfidence"
           />
           <DateField
             label="Ticket date"
             :value="edition.ticketDate.value"
             :is-estimated="edition.ticketDate.isEstimated"
+            :confidence="eventConfidence"
           />
           <DateField
             label="Announcement date"
             :value="edition.announcementDate.value"
             :is-estimated="edition.announcementDate.isEstimated"
+            :confidence="eventConfidence"
           />
           <p class="text-sm text-[var(--color-text)]">
             Range:

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -1,12 +1,28 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed } from "vue";
+import { useRoute, useRouter } from "vue-router";
 import EventCard from "../components/EventCard.vue";
 import ObfuscatedEmail from "../components/ObfuscatedEmail.vue";
-import { getEventSummaries, loadEventsData, sortEventSummaries, type TSortKey } from "../lib/events";
+import {
+  countActiveFilters,
+  extractCountryOptions,
+  extractMonthOptions,
+  extractStatusOptions,
+  filterEventSummaries,
+  getEventSummaries,
+  loadEventsData,
+  sortEventSummaries,
+  type TSortKey,
+} from "../lib/events";
+import type { TStatus } from "../../schemas/event.schema";
 
-const sortKey = ref<TSortKey>("eventDate");
-const events = loadEventsData();
 const CONTACT_EMAIL = "contact@tsurineko.org";
+
+const events = loadEventsData();
+const allSummaries = getEventSummaries(events);
+
+const route = useRoute();
+const router = useRouter();
 
 const sortOptions: Array<{ value: TSortKey; label: string }> = [
   { value: "eventDate", label: "Next event date" },
@@ -16,7 +32,87 @@ const sortOptions: Array<{ value: TSortKey; label: string }> = [
   { value: "name", label: "Name (A-Z)" },
 ];
 
-const sortedSummaries = computed(() => sortEventSummaries(getEventSummaries(events), sortKey.value));
+const statusLabels: Record<TStatus, string> = {
+  on_sale: "On sale",
+  waiting_list: "Waiting list",
+  scheduled: "Scheduled",
+  sold_out: "Sold out",
+  tba: "TBA",
+};
+
+const countryOptions = extractCountryOptions(allSummaries);
+const monthOptions = extractMonthOptions(allSummaries);
+const statusOptions = extractStatusOptions(allSummaries);
+
+function readQuery(key: string): string | null {
+  const raw = route.query[key];
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  return raw;
+}
+
+const sortKey = computed<TSortKey>({
+  get: () => {
+    const raw = readQuery("sort");
+    if (raw && sortOptions.some((option) => option.value === raw)) return raw as TSortKey;
+    return "eventDate";
+  },
+  set: (value) => updateQuery("sort", value === "eventDate" ? null : value),
+});
+
+const countryFilter = computed<string | null>({
+  get: () => {
+    const raw = readQuery("country");
+    return raw && countryOptions.includes(raw) ? raw : null;
+  },
+  set: (value) => updateQuery("country", value),
+});
+
+const monthFilter = computed<string | null>({
+  get: () => {
+    const raw = readQuery("month");
+    return raw && monthOptions.some((option) => option.value === raw) ? raw : null;
+  },
+  set: (value) => updateQuery("month", value),
+});
+
+const statusFilter = computed<TStatus | null>({
+  get: () => {
+    const raw = readQuery("status");
+    return raw && (statusOptions as string[]).includes(raw) ? (raw as TStatus) : null;
+  },
+  set: (value) => updateQuery("status", value),
+});
+
+function updateQuery(key: string, value: string | null): void {
+  const next = { ...route.query };
+  if (value === null || value === "") {
+    delete next[key];
+  } else {
+    next[key] = value;
+  }
+  router.replace({ query: next });
+}
+
+function clearFilters(): void {
+  const next = { ...route.query };
+  delete next.country;
+  delete next.month;
+  delete next.status;
+  router.replace({ query: next });
+}
+
+const activeFilters = computed(() => ({
+  country: countryFilter.value,
+  month: monthFilter.value,
+  status: statusFilter.value,
+}));
+
+const activeCount = computed(() => countActiveFilters(activeFilters.value));
+
+const visibleSummaries = computed(() => {
+  const filtered = filterEventSummaries(allSummaries, activeFilters.value);
+  return sortEventSummaries(filtered, sortKey.value);
+});
 </script>
 
 <template>
@@ -40,10 +136,7 @@ const sortedSummaries = computed(() => sortEventSummaries(getEventSummaries(even
             Open a pull request on GitHub
           </a>
           , or email
-          <ObfuscatedEmail
-            :email="CONTACT_EMAIL"
-            
-          />
+          <ObfuscatedEmail :email="CONTACT_EMAIL" />
           .
         </div>
       </div>
@@ -60,8 +153,78 @@ const sortedSummaries = computed(() => sortEventSummaries(getEventSummaries(even
       </label>
     </header>
 
-    <div class="grid gap-4">
-      <EventCard v-for="summary in sortedSummaries" :key="summary.event.slug" :summary="summary" />
+    <section
+      aria-label="Filter events"
+      class="mb-6 flex flex-wrap items-end gap-3 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3 shadow-sm"
+    >
+      <label class="flex flex-col text-xs uppercase tracking-wide text-[var(--color-muted)]">
+        Country
+        <select
+          v-model="countryFilter"
+          class="mt-1 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-strong)] px-3 py-2 text-sm text-[var(--color-text)] shadow-sm focus:border-[var(--color-secondary)] focus:outline-none"
+        >
+          <option :value="null">All countries</option>
+          <option v-for="country in countryOptions" :key="country" :value="country">
+            {{ country }}
+          </option>
+        </select>
+      </label>
+      <label class="flex flex-col text-xs uppercase tracking-wide text-[var(--color-muted)]">
+        Month
+        <select
+          v-model="monthFilter"
+          class="mt-1 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-strong)] px-3 py-2 text-sm text-[var(--color-text)] shadow-sm focus:border-[var(--color-secondary)] focus:outline-none"
+        >
+          <option :value="null">Any month</option>
+          <option v-for="option in monthOptions" :key="option.value" :value="option.value">
+            {{ option.label }}
+          </option>
+        </select>
+      </label>
+      <label class="flex flex-col text-xs uppercase tracking-wide text-[var(--color-muted)]">
+        Status
+        <select
+          v-model="statusFilter"
+          class="mt-1 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-strong)] px-3 py-2 text-sm text-[var(--color-text)] shadow-sm focus:border-[var(--color-secondary)] focus:outline-none"
+        >
+          <option :value="null">Any status</option>
+          <option v-for="status in statusOptions" :key="status" :value="status">
+            {{ statusLabels[status] }}
+          </option>
+        </select>
+      </label>
+      <button
+        v-if="activeCount > 0"
+        type="button"
+        class="ml-auto self-end rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-strong)] px-3 py-2 text-sm font-medium text-[var(--color-secondary)] transition hover:border-[var(--color-secondary)] hover:bg-[var(--color-secondary)] hover:text-[var(--color-surface-strong)]"
+        @click="clearFilters"
+      >
+        Clear filters ({{ activeCount }})
+      </button>
+    </section>
+
+    <div v-if="visibleSummaries.length > 0" class="grid gap-4">
+      <EventCard v-for="summary in visibleSummaries" :key="summary.event.slug" :summary="summary" />
+    </div>
+
+    <div
+      v-else
+      class="rounded-3xl border border-[var(--color-border)] bg-[var(--color-surface)] p-8 text-center shadow-lg shadow-[rgba(58,42,26,0.08)]"
+    >
+      <h2 class="text-xl font-semibold text-[var(--color-secondary)]">
+        No events match these filters
+      </h2>
+      <p class="mt-2 text-sm text-[var(--color-muted)]">
+        Try widening the range — clear a filter or two and the directory will expand.
+      </p>
+      <button
+        v-if="activeCount > 0"
+        type="button"
+        class="mt-4 inline-flex rounded-xl border border-[var(--color-primary)] bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-[var(--color-surface-strong)] transition hover:bg-[var(--color-primary-hover)]"
+        @click="clearFilters"
+      >
+        Clear filters
+      </button>
     </div>
   </section>
 </template>

--- a/src/pages/TicketsPage.vue
+++ b/src/pages/TicketsPage.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import EventCard from "../components/EventCard.vue";
+import {
+  getEventSummaries,
+  loadEventsData,
+  sortEventSummaries,
+  type IEventSummary,
+} from "../lib/events";
+
+const events = loadEventsData();
+const now = new Date();
+const allSummaries = getEventSummaries(events, now);
+
+function isOnSale(summary: IEventSummary): boolean {
+  return summary.event.status === "on_sale" || summary.event.status === "waiting_list";
+}
+
+function hasUpcomingTicketWindow(summary: IEventSummary): boolean {
+  if (!summary.ticketDate.value) return false;
+  return summary.ticketDate.value.getTime() >= now.getTime();
+}
+
+function hasEnded(summary: IEventSummary): boolean {
+  return summary.temporalState === "ended";
+}
+
+const onSaleNow = computed(() =>
+  sortEventSummaries(
+    allSummaries.filter((summary) => !hasEnded(summary) && isOnSale(summary)),
+    "ticketDate",
+  ),
+);
+
+const openingLater = computed(() =>
+  sortEventSummaries(
+    allSummaries.filter(
+      (summary) =>
+        !hasEnded(summary) && !isOnSale(summary) && hasUpcomingTicketWindow(summary),
+    ),
+    "ticketDate",
+  ),
+);
+
+const totalCount = computed(() => onSaleNow.value.length + openingLater.value.length);
+</script>
+
+<template>
+  <section>
+    <header class="mb-6">
+      <h1 class="text-3xl font-bold text-[var(--color-secondary)] sm:text-4xl">
+        Ticket watch
+      </h1>
+      <p class="mt-2 max-w-2xl text-sm text-[var(--color-muted)]">
+        Events you can act on — tickets already open, or opening soon. Sorted by ticket window.
+      </p>
+    </header>
+
+    <section v-if="onSaleNow.length > 0" class="mb-8">
+      <div class="mb-3 flex items-center gap-3">
+        <h2 class="text-xl font-semibold text-[var(--color-primary)]">
+          Tickets on sale now
+        </h2>
+        <span class="rounded-full bg-[rgba(194,86,42,0.12)] px-2 py-0.5 text-xs font-medium text-[var(--color-primary)]">
+          {{ onSaleNow.length }}
+        </span>
+      </div>
+      <div class="grid gap-4">
+        <EventCard
+          v-for="summary in onSaleNow"
+          :key="summary.event.slug"
+          :summary="summary"
+        />
+      </div>
+    </section>
+
+    <section v-if="openingLater.length > 0">
+      <div class="mb-3 flex items-center gap-3">
+        <h2 class="text-xl font-semibold text-[var(--color-secondary)]">
+          Tickets opening later
+        </h2>
+        <span class="rounded-full bg-[rgba(44,74,107,0.10)] px-2 py-0.5 text-xs font-medium text-[var(--color-secondary)]">
+          {{ openingLater.length }}
+        </span>
+      </div>
+      <div class="grid gap-4">
+        <EventCard
+          v-for="summary in openingLater"
+          :key="summary.event.slug"
+          :summary="summary"
+        />
+      </div>
+    </section>
+
+    <div
+      v-if="totalCount === 0"
+      class="rounded-3xl border border-[var(--color-border)] bg-[var(--color-surface)] p-8 text-center shadow-lg shadow-[rgba(58,42,26,0.08)]"
+    >
+      <h2 class="text-xl font-semibold text-[var(--color-secondary)]">
+        No ticket windows to watch right now
+      </h2>
+      <p class="mt-2 text-sm text-[var(--color-muted)]">
+        Nothing is currently on sale, and no upcoming ticket dates are recorded.
+        Check the full directory for events still being planned.
+      </p>
+      <RouterLink
+        to="/"
+        class="mt-4 inline-flex rounded-xl border border-[var(--color-primary)] bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-[var(--color-surface-strong)] transition hover:bg-[var(--color-primary-hover)]"
+      >
+        Browse events
+      </RouterLink>
+    </div>
+  </section>
+</template>

--- a/src/pages/WatchlistPage.vue
+++ b/src/pages/WatchlistPage.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import EventCard from "../components/EventCard.vue";
+import { getEventSummaries, loadEventsData, sortEventSummaries, type TSortKey } from "../lib/events";
+import { useWatchlist } from "../lib/watchlist";
+
+const { watchedSlugs, count } = useWatchlist();
+const events = loadEventsData();
+const sortKey = ref<TSortKey>("eventDate");
+
+const sortOptions: Array<{ value: TSortKey; label: string }> = [
+  { value: "eventDate", label: "Next event date" },
+  { value: "ticketDate", label: "Ticket date" },
+  { value: "status", label: "Status priority" },
+  { value: "lastUpdated", label: "Recently updated" },
+  { value: "name", label: "Name (A-Z)" },
+];
+
+const watchedSummaries = computed(() => {
+  const watched = events.filter((event) => watchedSlugs.value.has(event.slug));
+  return sortEventSummaries(getEventSummaries(watched), sortKey.value);
+});
+
+const missingCount = computed(() => watchedSlugs.value.size - watchedSummaries.value.length);
+</script>
+
+<template>
+  <section>
+    <header class="mb-6 flex flex-wrap items-end justify-between gap-4">
+      <div>
+        <h1 class="text-3xl font-bold text-[var(--color-secondary)] sm:text-4xl">
+          Your watchlist
+        </h1>
+        <p class="mt-2 max-w-2xl text-sm text-[var(--color-muted)]">
+          Events you're keeping an eye on. Stored in this browser — no account, no sync across devices.
+        </p>
+      </div>
+      <label v-if="count > 0" class="flex items-center gap-2 text-sm text-[var(--color-text)]">
+        <span>Sort by</span>
+        <select
+          v-model="sortKey"
+          class="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] shadow-sm focus:border-[var(--color-secondary)] focus:outline-none"
+        >
+          <option v-for="option in sortOptions" :key="option.value" :value="option.value">
+            {{ option.label }}
+          </option>
+        </select>
+      </label>
+    </header>
+
+    <div v-if="watchedSummaries.length > 0" class="grid gap-4">
+      <EventCard v-for="summary in watchedSummaries" :key="summary.event.slug" :summary="summary" />
+    </div>
+
+    <div
+      v-else
+      class="rounded-3xl border border-[var(--color-border)] bg-[var(--color-surface)] p-8 text-center shadow-lg shadow-[rgba(58,42,26,0.08)]"
+    >
+      <h2 class="text-xl font-semibold text-[var(--color-secondary)]">
+        Not watching any events yet
+      </h2>
+      <p class="mt-2 text-sm text-[var(--color-muted)]">
+        Browse the directory and tap <strong class="text-[var(--color-primary)]">Watch</strong> on any event to save it here.
+      </p>
+      <RouterLink
+        to="/"
+        class="mt-4 inline-flex rounded-xl border border-[var(--color-primary)] bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-[var(--color-surface-strong)] transition hover:bg-[var(--color-primary-hover)]"
+      >
+        Browse events
+      </RouterLink>
+    </div>
+
+    <p
+      v-if="missingCount > 0"
+      class="mt-4 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-muted)]"
+    >
+      {{ missingCount }} watched {{ missingCount === 1 ? "event is" : "events are" }} no longer in the directory.
+    </p>
+  </section>
+</template>

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,6 +1,7 @@
 import type { RouteRecordRaw } from "vue-router";
 import HomePage from "./pages/HomePage.vue";
 import EventPage from "./pages/EventPage.vue";
+import TicketsPage from "./pages/TicketsPage.vue";
 import WatchlistPage from "./pages/WatchlistPage.vue";
 
 export const routes: RouteRecordRaw[] = [
@@ -14,6 +15,11 @@ export const routes: RouteRecordRaw[] = [
     name: "event",
     component: EventPage,
     props: true,
+  },
+  {
+    path: "/tickets",
+    name: "tickets",
+    component: TicketsPage,
   },
   {
     path: "/watchlist",

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,6 +1,7 @@
 import type { RouteRecordRaw } from "vue-router";
 import HomePage from "./pages/HomePage.vue";
 import EventPage from "./pages/EventPage.vue";
+import WatchlistPage from "./pages/WatchlistPage.vue";
 
 export const routes: RouteRecordRaw[] = [
   {
@@ -13,5 +14,10 @@ export const routes: RouteRecordRaw[] = [
     name: "event",
     component: EventPage,
     props: true,
+  },
+  {
+    path: "/watchlist",
+    name: "watchlist",
+    component: WatchlistPage,
   },
 ];

--- a/tests/confidence.spec.ts
+++ b/tests/confidence.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { IEventData } from "../schemas/event.schema";
+import { formatEstimatedLabel, getEventSummaries } from "../src/lib/events";
+import { classifyConfidence } from "../src/lib/predictions";
+
+function makeEvent(slug: string, historicalStartDates: string[]): IEventData {
+  return {
+    name: slug,
+    slug,
+    location: { city: "City", country: "Country", venue: "Venue" },
+    links: { website: null, fetlife: null, mailingList: null, contactEmail: null },
+    status: "tba",
+    lastUpdated: "2026-04-01",
+    historicalEditions: historicalStartDates.map((startDate) => ({
+      startDate,
+      endDate: startDate,
+      announcementDate: null,
+      ticketSaleDate: null,
+      soldOutDate: null,
+      sourceNotes: "",
+    })),
+    nextEdition: {
+      startDate: null,
+      endDate: null,
+      announcementDate: null,
+      ticketSaleDate: null,
+      ticketUrl: null,
+      status: "tba",
+    },
+  };
+}
+
+describe("classifyConfidence", () => {
+  it("sample size 0 = low (pure fallback cadence)", () => {
+    expect(classifyConfidence(0)).toBe("low");
+  });
+
+  it("sample size 1 or 2 = medium (one or two observed intervals)", () => {
+    expect(classifyConfidence(1)).toBe("medium");
+    expect(classifyConfidence(2)).toBe("medium");
+  });
+
+  it("sample size 3+ = high (median over multiple intervals)", () => {
+    expect(classifyConfidence(3)).toBe("high");
+    expect(classifyConfidence(10)).toBe("high");
+  });
+});
+
+describe("formatEstimatedLabel", () => {
+  it("capitalises the confidence level after 'Estimated · '", () => {
+    expect(formatEstimatedLabel("high")).toBe("Estimated · High");
+    expect(formatEstimatedLabel("medium")).toBe("Estimated · Medium");
+    expect(formatEstimatedLabel("low")).toBe("Estimated · Low");
+  });
+});
+
+describe("getEventSummaries confidence field", () => {
+  it("assigns low confidence when there are 0-1 historical editions", () => {
+    const zero = getEventSummaries([makeEvent("zero", [])])[0];
+    const one = getEventSummaries([makeEvent("one", ["2025-05-01"])])[0];
+    expect(zero.confidence).toBe("low");
+    expect(one.confidence).toBe("low");
+  });
+
+  it("assigns medium confidence with 2-3 historical editions (1-2 intervals)", () => {
+    const two = getEventSummaries([makeEvent("two", ["2024-05-01", "2025-05-01"])])[0];
+    const three = getEventSummaries([
+      makeEvent("three", ["2023-05-01", "2024-05-01", "2025-05-01"]),
+    ])[0];
+    expect(two.confidence).toBe("medium");
+    expect(three.confidence).toBe("medium");
+  });
+
+  it("assigns high confidence with 4+ historical editions (3+ intervals)", () => {
+    const four = getEventSummaries([
+      makeEvent("four", ["2022-05-01", "2023-05-01", "2024-05-01", "2025-05-01"]),
+    ])[0];
+    expect(four.confidence).toBe("high");
+  });
+});

--- a/tests/events-filters.spec.ts
+++ b/tests/events-filters.spec.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import type { IEventData, TStatus } from "../schemas/event.schema";
+import {
+  countActiveFilters,
+  EMPTY_FILTERS,
+  extractCountryOptions,
+  extractMonthOptions,
+  extractStatusOptions,
+  filterEventSummaries,
+  getEventSummaries,
+} from "../src/lib/events";
+
+function makeEvent(overrides: Partial<IEventData> & Pick<IEventData, "slug">): IEventData {
+  return {
+    name: overrides.name ?? `Event ${overrides.slug}`,
+    slug: overrides.slug,
+    location: overrides.location ?? { city: "City", country: "Country", venue: "Venue" },
+    links: overrides.links ?? { website: null, fetlife: null, mailingList: null, contactEmail: null },
+    status: overrides.status ?? "scheduled",
+    lastUpdated: overrides.lastUpdated ?? "2026-04-01",
+    historicalEditions: overrides.historicalEditions ?? [],
+    nextEdition: overrides.nextEdition ?? {
+      startDate: null,
+      endDate: null,
+      announcementDate: null,
+      ticketSaleDate: null,
+      ticketUrl: null,
+      status: "tba",
+    },
+  };
+}
+
+const now = new Date("2026-04-01T00:00:00Z");
+
+const fixtures = [
+  makeEvent({
+    slug: "austrian-rope-retreat",
+    location: { city: "Zobern", country: "Austria", venue: "Venue A" },
+    status: "scheduled",
+    nextEdition: {
+      startDate: "2026-09-17",
+      endDate: "2026-09-21",
+      announcementDate: null,
+      ticketSaleDate: null,
+      ticketUrl: null,
+      status: "scheduled",
+    },
+  }),
+  makeEvent({
+    slug: "kasumi-hourai-akane-antwerp",
+    location: { city: "Antwerp", country: "Belgium", venue: "Venue B" },
+    status: "on_sale",
+    nextEdition: {
+      startDate: "2026-05-01",
+      endDate: "2026-05-04",
+      announcementDate: null,
+      ticketSaleDate: "2026-01-20",
+      ticketUrl: null,
+      status: "on_sale",
+    },
+  }),
+  makeEvent({
+    slug: "pinse-camp",
+    location: { city: "Sonder Felding", country: "Denmark", venue: "Venue C" },
+    status: "sold_out",
+    nextEdition: {
+      startDate: "2026-05-22",
+      endDate: "2026-05-25",
+      announcementDate: null,
+      ticketSaleDate: null,
+      ticketUrl: null,
+      status: "sold_out",
+    },
+  }),
+  makeEvent({
+    slug: "onawa-asobi-europe",
+    location: { city: "Antwerp", country: "Belgium", venue: "Venue D" },
+    status: "scheduled",
+    nextEdition: {
+      startDate: "2026-09-26",
+      endDate: "2026-09-27",
+      announcementDate: null,
+      ticketSaleDate: null,
+      ticketUrl: null,
+      status: "scheduled",
+    },
+  }),
+];
+
+const summaries = getEventSummaries(fixtures, now);
+
+describe("filterEventSummaries", () => {
+  it("returns all summaries with empty filters", () => {
+    expect(filterEventSummaries(summaries, EMPTY_FILTERS)).toHaveLength(4);
+  });
+
+  it("filters by country", () => {
+    const result = filterEventSummaries(summaries, { ...EMPTY_FILTERS, country: "Belgium" });
+    expect(result.map((summary) => summary.event.slug)).toEqual([
+      "kasumi-hourai-akane-antwerp",
+      "onawa-asobi-europe",
+    ]);
+  });
+
+  it("filters by status", () => {
+    const result = filterEventSummaries(summaries, { ...EMPTY_FILTERS, status: "sold_out" });
+    expect(result.map((summary) => summary.event.slug)).toEqual(["pinse-camp"]);
+  });
+
+  it("filters by month (YYYY-MM against nextDate)", () => {
+    const result = filterEventSummaries(summaries, { ...EMPTY_FILTERS, month: "2026-09" });
+    expect(result.map((summary) => summary.event.slug).sort()).toEqual([
+      "austrian-rope-retreat",
+      "onawa-asobi-europe",
+    ]);
+  });
+
+  it("ANDs multiple filters", () => {
+    const result = filterEventSummaries(summaries, {
+      country: "Belgium",
+      month: "2026-09",
+      status: null,
+    });
+    expect(result.map((summary) => summary.event.slug)).toEqual(["onawa-asobi-europe"]);
+  });
+
+  it("excludes summaries without a resolved nextDate when month filter is set", () => {
+    const withoutDate = getEventSummaries(
+      [...fixtures, makeEvent({ slug: "no-dates", status: "tba" })],
+      now,
+    );
+    const result = filterEventSummaries(withoutDate, { ...EMPTY_FILTERS, month: "2026-09" });
+    expect(result.some((summary) => summary.event.slug === "no-dates")).toBe(false);
+  });
+});
+
+describe("option extractors", () => {
+  it("extractCountryOptions returns unique sorted countries", () => {
+    expect(extractCountryOptions(summaries)).toEqual(["Austria", "Belgium", "Denmark"]);
+  });
+
+  it("extractMonthOptions returns sorted year-month values with labels", () => {
+    const options = extractMonthOptions(summaries);
+    expect(options.map((option) => option.value)).toEqual(["2026-05", "2026-09"]);
+    expect(options[0].label).toMatch(/May 2026/);
+  });
+
+  it("extractStatusOptions returns statuses in priority order, only those present", () => {
+    expect(extractStatusOptions(summaries)).toEqual(["on_sale", "scheduled", "sold_out"]);
+  });
+});
+
+describe("countActiveFilters", () => {
+  it("counts non-null filter fields", () => {
+    expect(countActiveFilters(EMPTY_FILTERS)).toBe(0);
+    expect(countActiveFilters({ country: "Belgium", month: null, status: null })).toBe(1);
+    expect(countActiveFilters({ country: "Belgium", month: "2026-09", status: "on_sale" as TStatus })).toBe(3);
+  });
+});

--- a/tests/site-happy-path.spec.ts
+++ b/tests/site-happy-path.spec.ts
@@ -3,9 +3,12 @@ import { mount } from "@vue/test-utils";
 import { createMemoryHistory, createRouter } from "vue-router";
 import HomePage from "../src/pages/HomePage.vue";
 import EventPage from "../src/pages/EventPage.vue";
+import TicketsPage from "../src/pages/TicketsPage.vue";
+import WatchlistPage from "../src/pages/WatchlistPage.vue";
 import ObfuscatedEmail from "../src/components/ObfuscatedEmail.vue";
 import { routes } from "../src/router";
 import { loadEventsData, sortEventSummaries, getEventSummaries } from "../src/lib/events";
+import { _resetWatchlistForTests } from "../src/lib/watchlist";
 
 describe("buyer guide website", () => {
   it("sorts by event date with confirmed before estimated", () => {
@@ -81,6 +84,38 @@ describe("buyer guide website", () => {
     expect(wrapper.text()).toContain("Official links");
     expect(wrapper.text()).toContain("Temporal state");
     expect(wrapper.text()).toContain("Reveal contact email");
+  });
+
+  it("renders tickets page with on-sale and opening-later sections", async () => {
+    const router = createRouter({ history: createMemoryHistory(), routes });
+    router.push("/tickets");
+    await router.isReady();
+
+    const wrapper = mount(TicketsPage, {
+      global: { plugins: [router] },
+    });
+
+    expect(wrapper.text()).toContain("Ticket watch");
+    // The split depends on current event data state, but the page must render one or the other section,
+    // or else the empty-state heading if neither applies.
+    const hasOnSale = wrapper.text().includes("Tickets on sale now");
+    const hasOpeningLater = wrapper.text().includes("Tickets opening later");
+    const hasEmptyState = wrapper.text().includes("No ticket windows to watch");
+    expect(hasOnSale || hasOpeningLater || hasEmptyState).toBe(true);
+  });
+
+  it("renders watchlist page empty state when nothing is watched", async () => {
+    _resetWatchlistForTests();
+    const router = createRouter({ history: createMemoryHistory(), routes });
+    router.push("/watchlist");
+    await router.isReady();
+
+    const wrapper = mount(WatchlistPage, {
+      global: { plugins: [router] },
+    });
+
+    expect(wrapper.text()).toContain("Your watchlist");
+    expect(wrapper.text()).toContain("Not watching any events yet");
   });
 
   it("shows button before reveal then plain text email link after click", async () => {

--- a/tests/site-happy-path.spec.ts
+++ b/tests/site-happy-path.spec.ts
@@ -35,20 +35,23 @@ describe("buyer guide website", () => {
     expect(ropeLinkedWinter?.nextDate.isEstimated).toBe(true);
   });
 
-  it("renders home cards with sort control", () => {
+  it("renders home cards with sort control and filters", async () => {
+    const router = createRouter({ history: createMemoryHistory(), routes });
+    router.push("/");
+    await router.isReady();
+
     const wrapper = mount(HomePage, {
       global: {
-        stubs: {
-          RouterLink: {
-            template: "<a><slot /></a>",
-          },
-        },
+        plugins: [router],
       },
     });
 
     expect(wrapper.text()).toContain("Upcoming Events");
-    expect(wrapper.find("select").exists()).toBe(true);
+    expect(wrapper.findAll("select").length).toBeGreaterThanOrEqual(4);
     expect(wrapper.text()).toContain("Sort by");
+    expect(wrapper.text()).toContain("Country");
+    expect(wrapper.text()).toContain("Month");
+    expect(wrapper.text()).toContain("Status");
     expect(wrapper.text()).toContain("Missing an event?");
     expect(wrapper.text()).toContain("Open a pull request on GitHub");
     expect(

--- a/tests/site-happy-path.spec.ts
+++ b/tests/site-happy-path.spec.ts
@@ -8,7 +8,7 @@ import WatchlistPage from "../src/pages/WatchlistPage.vue";
 import ObfuscatedEmail from "../src/components/ObfuscatedEmail.vue";
 import { routes } from "../src/router";
 import { loadEventsData, sortEventSummaries, getEventSummaries } from "../src/lib/events";
-import { _resetWatchlistForTests } from "../src/lib/watchlist";
+import { _resetWatchlistForTests, useWatchlist } from "../src/lib/watchlist";
 
 describe("buyer guide website", () => {
   it("sorts by event date with confirmed before estimated", () => {
@@ -116,6 +116,78 @@ describe("buyer guide website", () => {
 
     expect(wrapper.text()).toContain("Your watchlist");
     expect(wrapper.text()).toContain("Not watching any events yet");
+  });
+
+  it("watchlist page renders the watched event after watch()", async () => {
+    _resetWatchlistForTests();
+    const watchlist = useWatchlist();
+    watchlist.watch("austrian-rope-retreat");
+
+    const router = createRouter({ history: createMemoryHistory(), routes });
+    router.push("/watchlist");
+    await router.isReady();
+
+    const wrapper = mount(WatchlistPage, {
+      global: { plugins: [router] },
+    });
+
+    expect(wrapper.text()).toContain("Austrian Rope Retreat");
+    expect(wrapper.text()).not.toContain("Not watching any events yet");
+  });
+
+  it("watchlist page flags watched slugs that are no longer in the directory", async () => {
+    _resetWatchlistForTests();
+    const watchlist = useWatchlist();
+    watchlist.watch("slug-that-does-not-exist-in-data");
+
+    const router = createRouter({ history: createMemoryHistory(), routes });
+    router.push("/watchlist");
+    await router.isReady();
+
+    const wrapper = mount(WatchlistPage, {
+      global: { plugins: [router] },
+    });
+
+    expect(wrapper.text()).toContain("no longer in the directory");
+  });
+
+  it("home page filters by country when URL has ?country=Belgium", async () => {
+    const router = createRouter({ history: createMemoryHistory(), routes });
+    router.push("/?country=Belgium");
+    await router.isReady();
+
+    const wrapper = mount(HomePage, {
+      global: { plugins: [router] },
+    });
+
+    expect(wrapper.text()).toContain("Kasumi Hourai");
+    expect(wrapper.text()).not.toContain("Austrian Rope Retreat");
+    expect(wrapper.text()).toContain("Clear filters");
+  });
+
+  it("tickets page surfaces the on-sale heading with a known on-sale event", async () => {
+    const router = createRouter({ history: createMemoryHistory(), routes });
+    router.push("/tickets");
+    await router.isReady();
+
+    const wrapper = mount(TicketsPage, {
+      global: { plugins: [router] },
+    });
+
+    expect(wrapper.text()).toContain("Tickets on sale now");
+    expect(wrapper.text()).toContain("Kasumi Hourai");
+  });
+
+  it("event page shows not-found message for unknown slug", async () => {
+    const router = createRouter({ history: createMemoryHistory(), routes });
+    router.push("/events/this-slug-does-not-exist-in-the-directory");
+    await router.isReady();
+
+    const wrapper = mount(EventPage, {
+      global: { plugins: [router] },
+    });
+
+    expect(wrapper.text()).toContain("Event not found");
   });
 
   it("shows button before reveal then plain text email link after click", async () => {

--- a/tests/watchlist.spec.ts
+++ b/tests/watchlist.spec.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { _resetWatchlistForTests, useWatchlist } from "../src/lib/watchlist";
+
+const STORAGE_KEY = "shibari-events.watchlist.v1";
+
+describe("useWatchlist", () => {
+  beforeEach(() => {
+    _resetWatchlistForTests();
+  });
+
+  it("starts empty", () => {
+    const { watchedSlugs, count, isWatching } = useWatchlist();
+    expect(watchedSlugs.value.size).toBe(0);
+    expect(count.value).toBe(0);
+    expect(isWatching("any-slug")).toBe(false);
+  });
+
+  it("watch adds a slug and persists to localStorage", () => {
+    const { watch, isWatching, count } = useWatchlist();
+    watch("prague-shibari-festival-spring-edition");
+    expect(isWatching("prague-shibari-festival-spring-edition")).toBe(true);
+    expect(count.value).toBe(1);
+    const stored = localStorage.getItem(STORAGE_KEY);
+    expect(JSON.parse(stored as string)).toEqual(["prague-shibari-festival-spring-edition"]);
+  });
+
+  it("unwatch removes a slug and persists", () => {
+    const { watch, unwatch, isWatching, count } = useWatchlist();
+    watch("onawa-asobi-europe");
+    watch("pinse-camp");
+    unwatch("onawa-asobi-europe");
+    expect(isWatching("onawa-asobi-europe")).toBe(false);
+    expect(isWatching("pinse-camp")).toBe(true);
+    expect(count.value).toBe(1);
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) as string)).toEqual(["pinse-camp"]);
+  });
+
+  it("toggle flips membership", () => {
+    const { toggle, isWatching } = useWatchlist();
+    toggle("danish-shibari-festival");
+    expect(isWatching("danish-shibari-festival")).toBe(true);
+    toggle("danish-shibari-festival");
+    expect(isWatching("danish-shibari-festival")).toBe(false);
+  });
+
+  it("watching the same slug twice is a no-op", () => {
+    const { watch, count } = useWatchlist();
+    watch("pinse-camp");
+    watch("pinse-camp");
+    expect(count.value).toBe(1);
+  });
+
+  it("unwatching an unknown slug is a no-op", () => {
+    const { unwatch, count } = useWatchlist();
+    unwatch("never-saved");
+    expect(count.value).toBe(0);
+  });
+
+  it("two instances share the same reactive state", () => {
+    const a = useWatchlist();
+    const b = useWatchlist();
+    a.watch("ropelinked-summer-edition");
+    expect(b.isWatching("ropelinked-summer-edition")).toBe(true);
+    expect(b.count.value).toBe(1);
+  });
+
+  it("picks up changes from other tabs via storage events", () => {
+    const { count, isWatching } = useWatchlist();
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(["graines-de-cordes"]));
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: STORAGE_KEY,
+        newValue: JSON.stringify(["graines-de-cordes"]),
+      }),
+    );
+    expect(isWatching("graines-de-cordes")).toBe(true);
+    expect(count.value).toBe(1);
+  });
+
+  it("ignores malformed localStorage entries", () => {
+    localStorage.setItem(STORAGE_KEY, "not-json{");
+    _resetWatchlistForTests();
+    localStorage.setItem(STORAGE_KEY, "not-json{");
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: STORAGE_KEY, newValue: "not-json{" }),
+    );
+    const { count } = useWatchlist();
+    expect(count.value).toBe(0);
+  });
+});

--- a/tests/watchlist.spec.ts
+++ b/tests/watchlist.spec.ts
@@ -77,6 +77,30 @@ describe("useWatchlist", () => {
     expect(count.value).toBe(1);
   });
 
+  it("watch/unwatch read-modifies-writes so concurrent tab writes don't clobber", () => {
+    const { watch, unwatch, isWatching } = useWatchlist();
+
+    // Simulate: another tab wrote ["tab-a-slug"] to storage, but this tab's
+    // in-memory state still shows the old empty set (storage event hasn't propagated yet).
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(["tab-a-slug"]));
+
+    // This tab's user now watches a different slug.
+    watch("tab-b-slug");
+
+    // Both slugs must be persisted. If we mutated from the stale in-memory set,
+    // we'd have overwritten storage with only ["tab-b-slug"].
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) as string);
+    expect(persisted).toEqual(["tab-a-slug", "tab-b-slug"]);
+    expect(isWatching("tab-a-slug")).toBe(true);
+    expect(isWatching("tab-b-slug")).toBe(true);
+
+    // Symmetric case for unwatch.
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(["tab-a-slug", "tab-b-slug", "tab-c-slug"]));
+    unwatch("tab-b-slug");
+    const afterUnwatch = JSON.parse(localStorage.getItem(STORAGE_KEY) as string);
+    expect(afterUnwatch).toEqual(["tab-a-slug", "tab-c-slug"]);
+  });
+
   it("ignores malformed localStorage entries", () => {
     localStorage.setItem(STORAGE_KEY, "not-json{");
     _resetWatchlistForTests();


### PR DESCRIPTION
## Summary

Path A of the post-Day-0 roadmap — the four discovery features that turn the directory from "a static list" into "a place you come back to."

- **Watchlist** — Watch button on every event card and detail page; one click persists the slug to `localStorage` under `shibari-events.watchlist.v1`. Cross-tab sync via the `storage` event. `/watchlist` route shows the saved subset with the full sort options and a friendly empty state. Header count tells you what you've saved at a glance.
- **Filters** — Country / month / status dropdowns on the home page, AND-ed together, URL-bound via `router.replace` so filtered views are shareable and survive refresh. Dropdowns only surface values present in the data (no "Finland" option when there's no Finnish event). "Clear filters (N)" appears when any filter is active.
- **Confidence badges** — `classifyConfidence(sampleSize)` maps cadence-interval count to High / Medium / Low. Every "Estimated" pill on EventCard and DateField now carries the level, with a screen-reader aria-label. Users can tell "we're pretty sure" from "we're guessing."
- **Ticket watch** — `/tickets` groups events into "Tickets on sale now" (kakiiro heading) and "Tickets opening later" (secondary heading). Ended events never appear. Header nav adds a Tickets link (blue) alongside Watchlist (kakiiro) — reserving kakiiro for personal/saved actions.

Plus a round of **review fixes** from the /ship adversarial pass (Claude + Codex):

- \`readFromStorage\` + \`writeToStorage\` now wrap in try/catch so Safari private-mode \`SecurityError\` doesn't white-screen the SPA at mount.
- \`watch\`/\`unwatch\` read-modify-write against localStorage (not the in-memory ref) so concurrent tab writes can't clobber each other.
- \`toYearMonth\` + \`extractMonthOptions\` switched from UTC to local time so filter buckets match the dates users see on the cards.
- \`inferTemporalState\` now treats an event as still happening on its final calendar day (fixes Tickets page dropping events on the day they end).
- WatchButton keydown stoppers removed (dead code — buttons fire click natively on Enter/Space).

## Test plan

- [x] \`npm test\` — 43/43 pass (34 new: 9 watchlist, 13 filter, 10 confidence, 7 new view-flow regression, 1 cross-tab race regression)
- [x] \`npm run typecheck\` — tsc + vue-tsc clean
- [x] \`npm run validate:data\` — 14/14 events, 14/14 ledger slugs
- [x] \`BASE_PATH=/ npm run build\` — 153.7 KB JS (gzip 49.5 KB), 21.6 KB CSS
- [x] Browser QA: watch/unwatch flow, URL filter preload (\`?country=Belgium\`), dropdown → URL round-trip, confidence labels on multi-historical events, tickets sections populated, zero console errors

## Test Coverage

Coverage audit: **~75%** weighted (lib ~95%, views ~65% after 5 regression tests closed the highest-value flow gaps). Lib logic is tight; view-layer tests cover mount + headings, plus Watch→Watchlist populated, URL→filter subset, Tickets on-sale section, event not-found, and missing-slug hint.

Remaining 12 gaps are low-value (v-if existence assertions, aria-label text matches, size-prop branches) and intentionally deferred.

## Adversarial Review

- **Claude adversarial:** 5 findings surfaced; 3 auto-fixed before merge.
- **Codex adversarial:** 6 findings; converged with Claude's set on the high-severity ones and added one I'd missed (\`readFromStorage\` throws white-screen the SPA — now fixed).
- **Codex structured review:** CLI arg mismatch on this environment (\`--base\` + prompt), skipped. Claude adversarial covered the same ground.

Two findings deferred to [TODOS.md](./TODOS.md) as judgment calls:

- Confidence classifier threshold semantics (intervals vs editions) — opinion call.
- WatchlistPage UX for retired slugs — YAGNI until the first event is retired.

## Commits (bisectable)

1. \`:sparkles:\` 7e06ab8 — Watchlist (composable, button, page, 9 tests)
2. \`:mag:\` 7d17094 — Filters with URL state (13 tests)
3. \`:bar_chart:\` 30f6675 — Confidence badges (10 tests)
4. \`:ticket:\` 5a48db9 — Tickets page (2 mount tests)
5. \`test:\` f3afc81 — 5 view-flow regression tests from the coverage audit
6. \`fix:\` 057c3a7 — 4 auto-fixes + cross-tab race from adversarial review
7. \`docs:\` 08fbc25 — 2 deferred findings appended to TODOS.md

## What's next

Worker lane (v1 reminder emails — Resend + Turnstile + HMAC-signed confirm/unsubscribe) is still deferred. Adding Watchlist retroactively justifies the slug-immutability ledger work from Day 0: real users now have slugs stored in their browsers.