### PR TITLE
:sparkles: Split sourceNotes into internal/external

### DIFF
--- a/.cursor/rules/contributing.mdc
+++ b/.cursor/rules/contributing.mdc
@@ -8,13 +8,13 @@ alwaysApply: false
 
 - Keep contributions focused and verifiable.
 - Prefer one event per PR unless updates are tightly related.
-- Add source context in comments (`sourceNotes`) for future maintainers.
+- Put raw provenance in `internalSourceNotes` (URLs, FetLife event IDs, caveats) for future maintainers, and a clean human-readable summary in `externalSourceNotes` for the website.
 
 # Add a New Event
 
 1. Create `data/events/<event-slug>.jsonc`.
 2. Fill identity, links, status, `lastUpdated`, `historicalEditions`, and `nextEdition`.
-3. Include comments for non-obvious assumptions (especially timeline assumptions in `sourceNotes`).
+3. Include comments for non-obvious assumptions (especially timeline assumptions in `internalSourceNotes`; mirror the user-relevant caveats in `externalSourceNotes`).
 4. Ensure no past-only display behavior (runtime prediction should be possible from historical cadence when dates are unknown).
 
 # Update an Existing Event

--- a/.cursor/rules/data-format.mdc
+++ b/.cursor/rules/data-format.mdc
@@ -30,7 +30,8 @@ alwaysApply: false
   - `announcementDate` (nullable)
   - `ticketSaleDate` (nullable)
   - `soldOutDate` (nullable)
-  - `sourceNotes` (short provenance note)
+  - `internalSourceNotes` (maintainer-facing raw provenance: URLs, FetLife event IDs, ambiguity notes)
+  - `externalSourceNotes` (clean human-readable summary shown on the website)
 - `nextEdition`:
   - `startDate` / `endDate` (nullable when unknown)
   - `announcementDate` (nullable)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,15 +66,16 @@ Dates are ISO-8601 (YYYY-MM-DD). URLs are absolute (`https://…`) or `null`.
 The site derives `nextEdition` predictions at runtime from `historicalEditions` when confirmed values are missing. For the prediction to be useful:
 
 - Record every historical edition you can confirm, with as much date detail as possible (`announcementDate`, `ticketSaleDate` are especially valuable).
-- Put the source (FetLife event ID, official page URL, discussion permalink) in `sourceNotes`. This is what lets a future reviewer trust or correct the record.
+- Put the source (FetLife event ID, official page URL, discussion permalink, Wayback snapshot path) in `internalSourceNotes`. This is the maintainer-facing field — raw provenance is fine, ambiguity caveats welcome. It is what lets a future reviewer trust or correct the record.
+- Write a clean, human-readable summary in `externalSourceNotes`. This is what the website shows. One or two sentences in plain language: what we know, how we know it, and any honest caveats. No internal IDs or URLs unless they're useful to a reader.
 
 Prediction rules live in `src/lib/predictions.ts` and are spec'd in `docs/website-architecture-and-product-decisions.md`. If you change the algorithm, add a backtest in `tests/` and note the delta in your PR.
 
 ### Cancelled or skipped editions (optional)
 
-When you know an edition was cancelled or skipped (organiser announcement, FetLife post, mailing list note), record it in the optional `cancelledEditions` array. Each entry is `{ year, sourceNotes }`. The site uses these entries two ways:
+When you know an edition was cancelled or skipped (organiser announcement, FetLife post, mailing list note), record it in the optional `cancelledEditions` array. Each entry is `{ year, internalSourceNotes, externalSourceNotes }` — the same split as historical editions. The site uses these entries two ways:
 
-1. **Timeline display.** The cancelled year renders in the historical-editions table interleaved chronologically with held editions, struck through and muted, with your `sourceNotes` next to it.
+1. **Timeline display.** The cancelled year renders in the historical-editions table interleaved chronologically with held editions, struck through and muted, with your `externalSourceNotes` next to it.
 2. **Cadence sharpening.** The prediction algorithm treats a known cancelled year as a real period in the cadence, so an annual event with one cancellation no longer mispredicts the next edition halfway between two real years.
 
 Year-based metadata only supports annual events. The validator rejects entries that match a held edition's year, fall outside the held-edition range, or sit in a gap that does not fit an annual cadence (e.g. between two biennial editions). If you need biennial or sub-annual cancellation support, open an issue.
@@ -100,5 +101,6 @@ The email-reminder backend lives in `worker/`. Required secrets are documented i
 ## Style
 
 - Never include identifying personal data beyond what organizers publish themselves.
-- Keep `sourceNotes` factual and short. Cite the URL or FetLife event ID; do not editorialize.
+- Keep `internalSourceNotes` factual: cite the URL or FetLife event ID, note ambiguity, do not editorialize.
+- Keep `externalSourceNotes` clean and human-readable: one or two sentences a reader can understand without context. Strip raw IDs and URLs unless they're meant for the public.
 - Do not add fields outside the schema. If you think one is needed, open a discussion first.

--- a/TODOS.md
+++ b/TODOS.md
@@ -89,7 +89,7 @@ Items deferred from planning sessions. Add context, not just titles — future-y
 
 **What:** Below 640px, replace the horizontal-scroll `<table>` on `EventPage.vue` with a card-stacked layout per edition that prioritises Dates and Notes (the two columns users actually look at). Cancelled rows render as a smaller, muted card.
 
-**Why:** Today the `<table>` at `EventPage.vue:131-154` uses `min-w-[640px]` with `overflow-x-auto`, forcing horizontal scroll on phones to display columns mostly containing "Unknown" and em dashes. Once cancellations land, the most-clicked content (the Notes cell with sourceNotes URL) sits in the rightmost column and mobile users miss it.
+**Why:** Today the `<table>` at `EventPage.vue:131-154` uses `min-w-[640px]` with `overflow-x-auto`, forcing horizontal scroll on phones to display columns mostly containing "Unknown" and em dashes. Once cancellations land, the most-clicked content (the Notes cell with `externalSourceNotes`) sits in the rightmost column and mobile users miss it.
 
 **Pros:** Mobile users see the actually-useful columns first. Cancelled rows still distinguishable visually. Deeper alignment with DESIGN.md voice ("let the facts do the work").
 

--- a/data/event-template.jsonc
+++ b/data/event-template.jsonc
@@ -42,6 +42,14 @@
 
   // Prior editions you can confirm. Most recent first is fine; order doesn't
   // affect prediction logic but helps reviewers.
+  //
+  // Each edition carries TWO notes fields:
+  //   - internalSourceNotes: maintainer-facing provenance — raw URLs, FetLife
+  //     event IDs, Wayback snapshot paths, commit hashes, ambiguity caveats.
+  //     Anything a future reviewer needs to trust or correct the record.
+  //   - externalSourceNotes: shown on the website. One or two clean,
+  //     human-readable sentences summarising what we know and how confident
+  //     we are. No internal IDs or raw URLs unless they're meant for users.
   "historicalEditions": [
     {
       "startDate": "2025-07-04",
@@ -49,7 +57,8 @@
       "announcementDate": "2025-03-01", // when the event was publicly announced, or null
       "ticketSaleDate": "2025-03-15", // when tickets opened (critical for prediction), or null
       "soldOutDate": null, // when tickets sold out, or null
-      "sourceNotes": "FetLife event 1234567 confirms dates. Ticket sale date observed via mailing list."
+      "internalSourceNotes": "FetLife event 1234567 confirms dates. Ticket sale date observed via mailing list discussion 2025-03-15.",
+      "externalSourceNotes": "Confirmed by the official FetLife event listing; ticket-sale opening confirmed via the organiser's mailing list."
     }
   ],
 
@@ -65,20 +74,26 @@
   }
 
   // OPTIONAL — omit unless you have known cancellations to record.
-  // Each entry: { year: integer, sourceNotes: string explaining what happened
-  // and a source URL when possible }. Year-based, so this only covers annual
-  // events. The validator will reject entries whose year matches a held edition,
-  // falls outside the held-edition range, or sits in a gap that does not fit an
-  // annual cadence (e.g. recording a cancellation between two biennial editions).
-  // The site uses these entries both to surface the cancellation in the timeline
-  // (with a strike-through and your sourceNotes) and to sharpen the cadence
-  // prediction by treating the gap as N+1 annual periods.
+  // Each entry: { year: integer, internalSourceNotes, externalSourceNotes }.
+  // Both notes fields follow the same split as historicalEditions: internal
+  // is raw maintainer-facing provenance; external is the clean version shown
+  // on the site. Year-based, so this only covers annual events. The validator
+  // will reject entries whose year matches a held edition, falls outside the
+  // held-edition range, or sits in a gap that does not fit an annual cadence
+  // (e.g. recording a cancellation between two biennial editions).
+  // The site uses these entries both to surface the cancellation in the
+  // timeline (with a strike-through and the externalSourceNotes) and to
+  // sharpen the cadence prediction by treating the gap as N+1 annual periods.
   //
   // To use: add a comma after `nextEdition`'s closing `}` above, then add the
   // field below (uncommented):
   //
   // ,
   // "cancelledEditions": [
-  //   { "year": 2024, "sourceNotes": "Venue lost lease, see https://fetlife.com/events/123" }
+  //   {
+  //     "year": 2024,
+  //     "internalSourceNotes": "Venue lost lease, see https://fetlife.com/events/123 and organiser post 2024-03-12.",
+  //     "externalSourceNotes": "Cancelled when the venue lost its lease; confirmed by the organiser's announcement."
+  //   }
   // ]
 }

--- a/data/events/austrian-rope-retreat.jsonc
+++ b/data/events/austrian-rope-retreat.jsonc
@@ -21,7 +21,8 @@
       "announcementDate": "2025-12-01",
       "ticketSaleDate": "2025-12-01",
       "soldOutDate": null,
-      "sourceNotes": "Application-based format with lottery preference tiers."
+      "internalSourceNotes": "Application-based format with lottery preference tiers.",
+      "externalSourceNotes": "Inaugural edition: application-only with a lottery and preference tiers rather than a public ticket sale."
     }
   ],
   "nextEdition": {

--- a/data/events/bottoms-up.jsonc
+++ b/data/events/bottoms-up.jsonc
@@ -21,7 +21,8 @@
       "announcementDate": "2023-11-03",
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "First winter edition of Rogue Rope's gathering. Initially announced as 'Rogue Rope Winter 2024' in commit 344b126 (2023-11-03 18:53), retitled to 'Bottoms Up!' in commit 5264813 (2023-11-03 23:55). Dates from same commit ('When: 04/01/2024 14:00 -> 07/01/2024 16:00'). Ticket sale handled off-docs (gogogonzo shop / FetLife); not recorded in repo. Location: 'East of Antwerp, West of Lommel' (Mol area)."
+      "internalSourceNotes": "First winter edition of Rogue Rope's gathering. Initially announced as 'Rogue Rope Winter 2024' in commit 344b126 (2023-11-03 18:53), retitled to 'Bottoms Up!' in commit 5264813 (2023-11-03 23:55). Dates from same commit ('When: 04/01/2024 14:00 -> 07/01/2024 16:00'). Ticket sale handled off-docs (gogogonzo shop / FetLife); not recorded in repo. Location: 'East of Antwerp, West of Lommel' (Mol area).",
+      "externalSourceNotes": "Inaugural winter edition of Rogue Rope's gathering, announced and dated via the public docs repo. Ticket sale was handled off-site; opening date is not recorded."
     },
     {
       "startDate": "2025-01-02",
@@ -29,7 +30,8 @@
       "announcementDate": "2024-09-04",
       "ticketSaleDate": "2024-09-29",
       "soldOutDate": null,
-      "sourceNotes": "Announced as 'second indoor edition of Bottoms Up!' in commit 3983276 (2024-09-04). Dates first appeared in commit df739f3 (2024-09-10). Ticket sale opened 2024-09-29 20:00 per commit e7cbb6d (2024-09-23): 'Open ticket sales start on September 29th at 20:00.' Shop URL RRW25."
+      "internalSourceNotes": "Announced as 'second indoor edition of Bottoms Up!' in commit 3983276 (2024-09-04). Dates first appeared in commit df739f3 (2024-09-10). Ticket sale opened 2024-09-29 20:00 per commit e7cbb6d (2024-09-23): 'Open ticket sales start on September 29th at 20:00.' Shop URL RRW25.",
+      "externalSourceNotes": "Second indoor edition. Announcement and ticket-sale opening dates confirmed by the public docs repo."
     },
     {
       "startDate": "2026-02-18",
@@ -37,7 +39,8 @@
       "announcementDate": "2025-08-26",
       "ticketSaleDate": "2025-12-01",
       "soldOutDate": null,
-      "sourceNotes": "Initially announced under rebrand 'Oh Bondage! Up Yours!' in commit 94e96bd (2025-08-26): 'When: 18/02/2026 18:00 -> 22/02/2026 16:00', location 'Mol, Belgium' (commit 9770650 same day). Reverted to 'Bottoms Up!' branding in commit c4d9ae6 (2025-11-01). Initial ticket sale date was a copy-paste residue ('May 5th at 20:00'), corrected to 2025-12-01 20:00 in commit 84fc63c (2025-11-06): '📅 Tickets go on sale: December 1st, 2025 at 20:00' (per commit 42a171b). Price 169 EUR, capacity 42."
+      "internalSourceNotes": "Initially announced under rebrand 'Oh Bondage! Up Yours!' in commit 94e96bd (2025-08-26): 'When: 18/02/2026 18:00 -> 22/02/2026 16:00', location 'Mol, Belgium' (commit 9770650 same day). Reverted to 'Bottoms Up!' branding in commit c4d9ae6 (2025-11-01). Initial ticket sale date was a copy-paste residue ('May 5th at 20:00'), corrected to 2025-12-01 20:00 in commit 84fc63c (2025-11-06): '📅 Tickets go on sale: December 1st, 2025 at 20:00' (per commit 42a171b). Price 169 EUR, capacity 42.",
+      "externalSourceNotes": "Originally announced under a 'Oh Bondage! Up Yours!' rebrand in late August 2025, reverted to 'Bottoms Up!' branding in November. Tickets opened on 1 December 2025 per the public docs repo."
     }
   ],
   "nextEdition": {

--- a/data/events/danish-shibari-festival.jsonc
+++ b/data/events/danish-shibari-festival.jsonc
@@ -21,7 +21,8 @@
       "announcementDate": "2024-11-20",
       "ticketSaleDate": "2024-11-20",
       "soldOutDate": null,
-      "sourceNotes": "Official MyShibari page for the 2025 edition confirms date range and sold-out status: https://myshibari.dk/en/begivenheder/danish-shibari-festival-2025-2/. Event usually announced late in the previous year."
+      "internalSourceNotes": "Official MyShibari page for the 2025 edition confirms date range and sold-out status: https://myshibari.dk/en/begivenheder/danish-shibari-festival-2025-2/. Event usually announced late in the previous year.",
+      "externalSourceNotes": "Dates and sold-out status confirmed by the official MyShibari event page. Editions are typically announced late in the previous year."
     }
   ],
   "nextEdition": {

--- a/data/events/eurix-autumn-edition.jsonc
+++ b/data/events/eurix-autumn-edition.jsonc
@@ -21,7 +21,8 @@
       "announcementDate": "2012-07-29",
       "ticketSaleDate": "2012-07-29",
       "soldOutDate": null,
-      "sourceNotes": "EURIX No I — inaugural edition. Venue: schwelle7 (Uferstr. 6, Berlin-Wedding). Dates confirmed from Wayback snapshot web.archive.org/web/20120729165550/http://schwelle7.de:80/EURIXE.html ('10. - 15. SEPTEMBER 2012'). announce/ticket are Wayback upper bounds — fully-formed announcement already public at that snapshot date. Fee 100 EUR per couple / 50 EUR single."
+      "internalSourceNotes": "EURIX No I — inaugural edition. Venue: schwelle7 (Uferstr. 6, Berlin-Wedding). Dates confirmed from Wayback snapshot web.archive.org/web/20120729165550/http://schwelle7.de:80/EURIXE.html ('10. - 15. SEPTEMBER 2012'). announce/ticket are Wayback upper bounds — fully-formed announcement already public at that snapshot date. Fee 100 EUR per couple / 50 EUR single.",
+      "externalSourceNotes": "EURIX No I, the inaugural edition at the original schwelle7 venue. Dates confirmed by archived snapshots of the schwelle7 site; announcement and ticket-sale dates are upper bounds."
     },
     {
       "startDate": "2013-09-09",
@@ -29,7 +30,8 @@
       "announcementDate": "2013-05-14",
       "ticketSaleDate": "2013-05-14",
       "soldOutDate": null,
-      "sourceNotes": "EURIX No III. Venue: schwelle7, Berlin. Dates confirmed from Wayback web.archive.org/web/20130514041457/http://www.schwelle7.de:80/EURIXE.html ('09. - 14. September 2013')."
+      "internalSourceNotes": "EURIX No III. Venue: schwelle7, Berlin. Dates confirmed from Wayback web.archive.org/web/20130514041457/http://www.schwelle7.de:80/EURIXE.html ('09. - 14. September 2013').",
+      "externalSourceNotes": "EURIX No III at schwelle7, Berlin. Dates confirmed by archived snapshots of the schwelle7 site."
     },
     {
       "startDate": "2014-09-08",
@@ -37,7 +39,8 @@
       "announcementDate": "2014-04-26",
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "EURIX No V. Venue: schwelle7, Berlin. Dates confirmed from Wayback web.archive.org/web/20140426153410/ German text '8. - 13. September 2014' (English alt text has a '2013' typo)."
+      "internalSourceNotes": "EURIX No V. Venue: schwelle7, Berlin. Dates confirmed from Wayback web.archive.org/web/20140426153410/ German text '8. - 13. September 2014' (English alt text has a '2013' typo).",
+      "externalSourceNotes": "EURIX No V at schwelle7, Berlin. Dates confirmed by archived snapshots of the schwelle7 site."
     },
     {
       "startDate": "2015-09-07",
@@ -45,7 +48,8 @@
       "announcementDate": "2015-05-03",
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "EURIX No VII. Venue: schwelle7, Berlin. Dates from Wayback web.archive.org/web/20150503090854/ ('07. - 12. September 2015'). Core program Mon-Fri Sep 7-11; final party Sat Sep 12."
+      "internalSourceNotes": "EURIX No VII. Venue: schwelle7, Berlin. Dates from Wayback web.archive.org/web/20150503090854/ ('07. - 12. September 2015'). Core program Mon-Fri Sep 7-11; final party Sat Sep 12.",
+      "externalSourceNotes": "EURIX No VII at schwelle7, Berlin. Core program ran Monday-Friday with a final party on Saturday. Dates confirmed by archived snapshots of the schwelle7 site."
     },
     {
       "startDate": "2016-09-12",
@@ -53,7 +57,8 @@
       "announcementDate": "2016-09-12",
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "EURIX No IX. First edition at Alte Börse Marzahn (venue migration from schwelle7). Extended to 7 days (Mon-Sun) vs. previous 6-day format. Dates from Wayback web.archive.org/web/20160912101634/ ('12. - 18. September 2016'). announcementDate upper bound is the snapshot date (no earlier snapshot captured for this edition)."
+      "internalSourceNotes": "EURIX No IX. First edition at Alte Börse Marzahn (venue migration from schwelle7). Extended to 7 days (Mon-Sun) vs. previous 6-day format. Dates from Wayback web.archive.org/web/20160912101634/ ('12. - 18. September 2016'). announcementDate upper bound is the snapshot date (no earlier snapshot captured for this edition).",
+      "externalSourceNotes": "EURIX No IX, the first edition at Alte Börse Marzahn after the venue moved from schwelle7. The format extended from six to seven days. Dates confirmed by archived snapshots; announcement date is an upper bound."
     },
     {
       "startDate": "2017-09-18",
@@ -61,7 +66,8 @@
       "announcementDate": "2017-07-16",
       "ticketSaleDate": null,
       "soldOutDate": "2017-08-16",
-      "sourceNotes": "EURIX No XI. Venue: Alte Börse Marzahn, Berlin. soldOut upper bound from Wayback web.archive.org/web/20170816223032/ ('The regular program and the Beginner Course is SOLD OUT')."
+      "internalSourceNotes": "EURIX No XI. Venue: Alte Börse Marzahn, Berlin. soldOut upper bound from Wayback web.archive.org/web/20170816223032/ ('The regular program and the Beginner Course is SOLD OUT').",
+      "externalSourceNotes": "EURIX No XI at Alte Börse Marzahn, Berlin. Dates and sold-out status confirmed by archived snapshots of the official EURIX page; sold-out date is an upper bound."
     },
     {
       "startDate": "2018-10-22",
@@ -69,7 +75,8 @@
       "announcementDate": "2018-08-01",
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "EURIX No XIII. Venue: Holzmarkt/Säälchen, Berlin (second edition at this venue). announcementDate is Wayback upper bound."
+      "internalSourceNotes": "EURIX No XIII. Venue: Holzmarkt/Säälchen, Berlin (second edition at this venue). announcementDate is Wayback upper bound.",
+      "externalSourceNotes": "EURIX No XIII at Holzmarkt/Säälchen, Berlin. Dates confirmed by archived snapshots; announcement date is an upper bound."
     },
     {
       "startDate": "2019-10-21",
@@ -77,7 +84,8 @@
       "announcementDate": "2019-08-19",
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "EURIX No XV. Venue: Holzmarkt/Säälchen, Berlin."
+      "internalSourceNotes": "EURIX No XV. Venue: Holzmarkt/Säälchen, Berlin.",
+      "externalSourceNotes": "EURIX No XV at Holzmarkt/Säälchen, Berlin. Dates confirmed by archived snapshots of the official EURIX page."
     },
     {
       "startDate": "2020-10-19",
@@ -85,7 +93,8 @@
       "announcementDate": "2020-09-26",
       "ticketSaleDate": "2020-09-26",
       "soldOutDate": null,
-      "sourceNotes": "EURIX No XVII. Corona-era edition: reduced capacity ~80 participants with 3G hygiene concept. Venue: Holzmarkt/Säälchen, Berlin. Wayback web.archive.org/web/20200926214229/ notes 'This event is almost sold out'. Dates announced after Spring 2020 (XVI) cancellation."
+      "internalSourceNotes": "EURIX No XVII. Corona-era edition: reduced capacity ~80 participants with 3G hygiene concept. Venue: Holzmarkt/Säälchen, Berlin. Wayback web.archive.org/web/20200926214229/ notes 'This event is almost sold out'. Dates announced after Spring 2020 (XVI) cancellation.",
+      "externalSourceNotes": "EURIX No XVII, the COVID-era return after the Spring 2020 (XVI) cancellation. Held with reduced capacity (~80 participants) under a 3G hygiene concept. Dates confirmed by archived snapshots of the official EURIX page."
     },
     {
       "startDate": "2021-10-18",
@@ -93,7 +102,8 @@
       "announcementDate": "2021-04-02",
       "ticketSaleDate": "2021-04-02",
       "soldOutDate": "2021-10-26",
-      "sourceNotes": "EURIX No XIX. Venue: Holzmarkt/Säälchen, Berlin. announcementDate narrowed to 2021-03-06 -> 2021-04-02 window: 2021-03-06 snapshot only mentions XVIII; 2021-04-02 snapshot first mentions XIX ('The automn 2021 EURIX is planned for October, 18 - 23, 2021'). Registration was open as XVIII tickets (carry-over when XVIII cancelled) per 2021-07-08 snapshot ('All tickets remain valid and can be used for the next edition'). soldOutDate 2021-10-26 is upper bound (post-event snapshot); narrower window is 2021-07-30 -> 2021-10-26 since 2021-07-30 snapshot has no SOLD OUT marker."
+      "internalSourceNotes": "EURIX No XIX. Venue: Holzmarkt/Säälchen, Berlin. announcementDate narrowed to 2021-03-06 -> 2021-04-02 window: 2021-03-06 snapshot only mentions XVIII; 2021-04-02 snapshot first mentions XIX ('The automn 2021 EURIX is planned for October, 18 - 23, 2021'). Registration was open as XVIII tickets (carry-over when XVIII cancelled) per 2021-07-08 snapshot ('All tickets remain valid and can be used for the next edition'). soldOutDate 2021-10-26 is upper bound (post-event snapshot); narrower window is 2021-07-30 -> 2021-10-26 since 2021-07-30 snapshot has no SOLD OUT marker.",
+      "externalSourceNotes": "EURIX No XIX at Holzmarkt/Säälchen, Berlin. Tickets from the cancelled Spring 2021 (XVIII) edition were carried over per the organiser's announcement. Announcement and sold-out dates are upper bounds taken from archived snapshots of the official EURIX page."
     },
     {
       "startDate": "2022-11-07",
@@ -101,7 +111,8 @@
       "announcementDate": "2021-11-09",
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "EURIX No XXI. Venue: Holzmarkt/Säälchen, Berlin. Unusually held in November rather than October. Announced together with Spring 2022 (XX) in the same content update: 2021-10-26 snapshot has no XXI mention; 2021-11-09 snapshot lists 'coming up automn 2022: EURIX No XXI / November, 7 - 12, 2022'. No ticket-sale or sold-out signal observed on canonical page across 2022-05-23, 2022-08-19, 2022-10-02 snapshots."
+      "internalSourceNotes": "EURIX No XXI. Venue: Holzmarkt/Säälchen, Berlin. Unusually held in November rather than October. Announced together with Spring 2022 (XX) in the same content update: 2021-10-26 snapshot has no XXI mention; 2021-11-09 snapshot lists 'coming up automn 2022: EURIX No XXI / November, 7 - 12, 2022'. No ticket-sale or sold-out signal observed on canonical page across 2022-05-23, 2022-08-19, 2022-10-02 snapshots.",
+      "externalSourceNotes": "EURIX No XXI at Holzmarkt/Säälchen, Berlin. Unusually scheduled in November rather than the typical October slot. Announced together with the spring edition; no ticket-sale or sold-out signal recorded on the official page."
     },
     {
       "startDate": "2023-10-16",
@@ -109,7 +120,8 @@
       "announcementDate": "2022-05-23",
       "ticketSaleDate": "2023-06-01",
       "soldOutDate": null,
-      "sourceNotes": "sourceEventId=1328948 (FetLife event). felixruckert.de has no per-edition blog posts; dates derived from Wayback snapshots of /2015/10/01/eurix/. announcementDate is a Wayback upper bound (first snapshot listing No XXIII in 'coming up', 2022-05-23). ticketSaleDate is a Wayback upper bound (first snapshot with 'REGISTRATION is open!!', 2023-06-01). No sold-out snapshot found."
+      "internalSourceNotes": "sourceEventId=1328948 (FetLife event). felixruckert.de has no per-edition blog posts; dates derived from Wayback snapshots of /2015/10/01/eurix/. announcementDate is a Wayback upper bound (first snapshot listing No XXIII in 'coming up', 2022-05-23). ticketSaleDate is a Wayback upper bound (first snapshot with 'REGISTRATION is open!!', 2023-06-01). No sold-out snapshot found.",
+      "externalSourceNotes": "Confirmed by the official FetLife event listing. Announcement and ticket-sale dates are upper bounds taken from archived snapshots of the official EURIX page."
     },
     {
       "startDate": "2024-10-14",
@@ -117,7 +129,8 @@
       "announcementDate": "2023-02-07",
       "ticketSaleDate": "2024-07-16",
       "soldOutDate": "2024-10-05",
-      "sourceNotes": "sourceEventId=1539849 (FetLife event). Wayback 2023-02-07 snapshot lists No XXV in 'coming up' (announcement upper bound). Wayback 2024-07-16 snapshot shows 'Registration is open!' on No 25 banner (ticket-sale upper bound). Wayback 2024-10-05 snapshot states 'The festival is SOLD OUT!! Waitinglist is still available.'"
+      "internalSourceNotes": "sourceEventId=1539849 (FetLife event). Wayback 2023-02-07 snapshot lists No XXV in 'coming up' (announcement upper bound). Wayback 2024-07-16 snapshot shows 'Registration is open!' on No 25 banner (ticket-sale upper bound). Wayback 2024-10-05 snapshot states 'The festival is SOLD OUT!! Waitinglist is still available.'",
+      "externalSourceNotes": "Confirmed by the official FetLife event listing. Announcement, ticket-sale, and sold-out dates are upper bounds taken from archived snapshots of the official EURIX page."
     },
     {
       "startDate": "2025-10-20",
@@ -125,7 +138,8 @@
       "announcementDate": "2023-12-11",
       "ticketSaleDate": "2025-05-14",
       "soldOutDate": "2025-07-19",
-      "sourceNotes": "sourceEventId=1798958 (FetLife event). Wayback 2023-12-11 snapshot lists No XXVII in 'coming up' (announcement upper bound). Wayback 2025-05-14 snapshot shows 'Registration is open!' on No 27 banner (ticket-sale upper bound). Wayback 2025-07-19 snapshot states 'THE FESTIVAL IS SOLD OUT! (Some places left in the Absolute Beginner Course)'"
+      "internalSourceNotes": "sourceEventId=1798958 (FetLife event). Wayback 2023-12-11 snapshot lists No XXVII in 'coming up' (announcement upper bound). Wayback 2025-05-14 snapshot shows 'Registration is open!' on No 27 banner (ticket-sale upper bound). Wayback 2025-07-19 snapshot states 'THE FESTIVAL IS SOLD OUT! (Some places left in the Absolute Beginner Course)'",
+      "externalSourceNotes": "Confirmed by the official FetLife event listing. Announcement, ticket-sale, and sold-out dates are upper bounds taken from archived snapshots of the official EURIX page."
     }
   ],
   "nextEdition": {

--- a/data/events/eurix-spring-edition.jsonc
+++ b/data/events/eurix-spring-edition.jsonc
@@ -21,7 +21,8 @@
       "announcementDate": "2013-03-30",
       "ticketSaleDate": "2013-03-30",
       "soldOutDate": null,
-      "sourceNotes": "EURIX No II. Venue: schwelle7 (Uferstr. 6, Berlin-Wedding) — original EURIX venue before 2016. Announcements on schwelle7.de/EURIXE.html before the canonical felixruckert.de page existed. Dates confirmed from Wayback snapshot web.archive.org/web/20130330051119/http://www.schwelle7.de:80/EURIXE.html ('22. - 27. April 2013'). announce/ticket are Wayback upper bounds (registration open by snapshot date)."
+      "internalSourceNotes": "EURIX No II. Venue: schwelle7 (Uferstr. 6, Berlin-Wedding) — original EURIX venue before 2016. Announcements on schwelle7.de/EURIXE.html before the canonical felixruckert.de page existed. Dates confirmed from Wayback snapshot web.archive.org/web/20130330051119/http://www.schwelle7.de:80/EURIXE.html ('22. - 27. April 2013'). announce/ticket are Wayback upper bounds (registration open by snapshot date).",
+      "externalSourceNotes": "EURIX No II at the original schwelle7 venue. Dates confirmed by archived snapshots of the schwelle7 site; announcement and ticket-sale dates are upper bounds."
     },
     {
       "startDate": "2015-03-16",
@@ -29,7 +30,8 @@
       "announcementDate": "2015-02-04",
       "ticketSaleDate": "2015-02-04",
       "soldOutDate": null,
-      "sourceNotes": "EURIX No VI. Venue: schwelle7, Berlin. Dates confirmed from Wayback snapshot web.archive.org/web/20150204053020/ ('16. - 21. März 2015'). announce/ticket are Wayback upper bounds. All-Berlin presenter lineup this edition (unusual for a European-exchange festival). EURIX IV (Spring 2014) happened but has no recoverable date from Wayback — snapshot gap Sept 2013 to April 2014."
+      "internalSourceNotes": "EURIX No VI. Venue: schwelle7, Berlin. Dates confirmed from Wayback snapshot web.archive.org/web/20150204053020/ ('16. - 21. März 2015'). announce/ticket are Wayback upper bounds. All-Berlin presenter lineup this edition (unusual for a European-exchange festival). EURIX IV (Spring 2014) happened but has no recoverable date from Wayback — snapshot gap Sept 2013 to April 2014.",
+      "externalSourceNotes": "EURIX No VI at schwelle7, Berlin, with an unusual all-Berlin presenter lineup. Dates confirmed by archived snapshots; announcement and ticket-sale dates are upper bounds. EURIX IV (Spring 2014) ran but its dates are not recoverable from the public archive."
     },
     {
       "startDate": "2016-03-14",
@@ -37,7 +39,8 @@
       "announcementDate": "2016-01-11",
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "EURIX No VIII. Venue: schwelle7, Berlin. Dates confirmed from Wayback web.archive.org/web/20160111215830/ ('14. - 19. März 2016'). announce is Wayback upper bound."
+      "internalSourceNotes": "EURIX No VIII. Venue: schwelle7, Berlin. Dates confirmed from Wayback web.archive.org/web/20160111215830/ ('14. - 19. März 2016'). announce is Wayback upper bound.",
+      "externalSourceNotes": "EURIX No VIII at schwelle7, Berlin. Dates confirmed by archived snapshots; announcement date is an upper bound."
     },
     {
       "startDate": "2017-03-20",
@@ -45,7 +48,8 @@
       "announcementDate": "2016-12-03",
       "ticketSaleDate": "2016-12-03",
       "soldOutDate": null,
-      "sourceNotes": "EURIX No X. Venue: Alte Börse Marzahn, Berlin (venue moved from schwelle7 at EURIX IX, Sep 2016). Dates confirmed from Wayback web.archive.org/web/20161203095351/ — this is also the earliest snapshot of the canonical felixruckert.de/2015/10/01/eurix/ page. 'Registration for EURIX is open now: schwelle7 (at) gmx.de' quoted in same snapshot."
+      "internalSourceNotes": "EURIX No X. Venue: Alte Börse Marzahn, Berlin (venue moved from schwelle7 at EURIX IX, Sep 2016). Dates confirmed from Wayback web.archive.org/web/20161203095351/ — this is also the earliest snapshot of the canonical felixruckert.de/2015/10/01/eurix/ page. 'Registration for EURIX is open now: schwelle7 (at) gmx.de' quoted in same snapshot.",
+      "externalSourceNotes": "EURIX No X, the first spring edition at Alte Börse Marzahn after the venue moved from schwelle7. Dates and registration opening confirmed by archived snapshots of the official EURIX page."
     },
     {
       "startDate": "2018-03-12",
@@ -53,7 +57,8 @@
       "announcementDate": "2017-10-18",
       "ticketSaleDate": null,
       "soldOutDate": "2018-02-16",
-      "sourceNotes": "EURIX No XII. First edition at Holzmarkt/Säälchen (venue change from Alte Börse Marzahn). Dates from Wayback web.archive.org/web/20171018051823/ ('planned for March, 12-18, 2018'; final dates 12-17). Wayback 2018-02-16 states 'The European Rigger&Model Exchange No 12/ March 2018/ Berlin is SOLD OUT by now.' A 'EURIX BY THE SEA' side event in Royan, France ran Jun 24-29 2018 as overflow."
+      "internalSourceNotes": "EURIX No XII. First edition at Holzmarkt/Säälchen (venue change from Alte Börse Marzahn). Dates from Wayback web.archive.org/web/20171018051823/ ('planned for March, 12-18, 2018'; final dates 12-17). Wayback 2018-02-16 states 'The European Rigger&Model Exchange No 12/ March 2018/ Berlin is SOLD OUT by now.' A 'EURIX BY THE SEA' side event in Royan, France ran Jun 24-29 2018 as overflow.",
+      "externalSourceNotes": "EURIX No XII, the first edition at Holzmarkt/Säälchen after the venue moved from Alte Börse Marzahn. Dates and sold-out status confirmed by archived snapshots of the official EURIX page. An overflow side event 'EURIX BY THE SEA' ran in Royan, France in June 2018."
     },
     {
       "startDate": "2019-04-15",
@@ -61,7 +66,8 @@
       "announcementDate": "2019-02-23",
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "EURIX No XIV. Venue: Holzmarkt/Säälchen, Berlin. Dates from Wayback snapshot dated 2019-02-23 which is also the announcement upper bound."
+      "internalSourceNotes": "EURIX No XIV. Venue: Holzmarkt/Säälchen, Berlin. Dates from Wayback snapshot dated 2019-02-23 which is also the announcement upper bound.",
+      "externalSourceNotes": "EURIX No XIV at Holzmarkt/Säälchen, Berlin. Dates confirmed by archived snapshots; announcement date is an upper bound."
     },
     {
       "startDate": "2022-05-09",
@@ -69,7 +75,8 @@
       "announcementDate": "2021-11-09",
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "EURIX No XX. Venue: Holzmarkt/Säälchen, Berlin. Announcement tightened to 2021-10-26 -> 2021-11-09 window: 2021-10-26 snapshot only teases 'EURIX No XX / spring 2021' (typo for 2022) with no dates; 2021-11-09 snapshot first has full dates 'No 20 will happen from May, 9 - 14, 2022'. XX and XXI announced together. No ticket-sale or sold-out signal found on canonical page in surrounding snapshots. Spring 2020 (XVI) and Spring 2021 (XVIII) editions were cancelled due to Corona — not listed as historical editions since they didn't take place."
+      "internalSourceNotes": "EURIX No XX. Venue: Holzmarkt/Säälchen, Berlin. Announcement tightened to 2021-10-26 -> 2021-11-09 window: 2021-10-26 snapshot only teases 'EURIX No XX / spring 2021' (typo for 2022) with no dates; 2021-11-09 snapshot first has full dates 'No 20 will happen from May, 9 - 14, 2022'. XX and XXI announced together. No ticket-sale or sold-out signal found on canonical page in surrounding snapshots. Spring 2020 (XVI) and Spring 2021 (XVIII) editions were cancelled due to Corona — not listed as historical editions since they didn't take place.",
+      "externalSourceNotes": "EURIX No XX, the first spring edition after the COVID-era cancellations of EURIX XVI (Spring 2020) and XVIII (Spring 2021). Announced together with the autumn edition; dates confirmed by archived snapshots of the official EURIX page."
     },
     {
       "startDate": "2023-04-17",
@@ -77,7 +84,8 @@
       "announcementDate": "2022-05-23",
       "ticketSaleDate": "2023-02-07",
       "soldOutDate": null,
-      "sourceNotes": "sourceEventId=1209105 (FetLife event). felixruckert.de has no per-edition blog posts; dates derived from Wayback snapshots of the canonical /2015/10/01/eurix/ page. announcementDate is a Wayback upper bound (first snapshot listing the edition in 'coming up' block, 2022-05-23). ticketSaleDate is a Wayback upper bound (first snapshot with active-edition banner, 2023-02-07). Real dates may be earlier."
+      "internalSourceNotes": "sourceEventId=1209105 (FetLife event). felixruckert.de has no per-edition blog posts; dates derived from Wayback snapshots of the canonical /2015/10/01/eurix/ page. announcementDate is a Wayback upper bound (first snapshot listing the edition in 'coming up' block, 2022-05-23). ticketSaleDate is a Wayback upper bound (first snapshot with active-edition banner, 2023-02-07). Real dates may be earlier.",
+      "externalSourceNotes": "Confirmed by the official FetLife event listing. Announcement and ticket-sale dates are upper bounds taken from archived snapshots of the official EURIX page."
     },
     {
       "startDate": "2024-04-01",
@@ -85,7 +93,8 @@
       "announcementDate": "2023-02-07",
       "ticketSaleDate": "2023-12-11",
       "soldOutDate": "2024-03-05",
-      "sourceNotes": "sourceEventId=1404378 (FetLife event). Wayback 2023-02-07 snapshot lists EURIX No XXIV in 'coming up' (announcement upper bound). Wayback 2023-12-11 snapshot shows 'Registration is open!' on No 24 banner (ticket-sale upper bound). Wayback 2024-03-05 snapshot states 'The European Rigger&Model Exchange No 24 is SOLD OUT!'"
+      "internalSourceNotes": "sourceEventId=1404378 (FetLife event). Wayback 2023-02-07 snapshot lists EURIX No XXIV in 'coming up' (announcement upper bound). Wayback 2023-12-11 snapshot shows 'Registration is open!' on No 24 banner (ticket-sale upper bound). Wayback 2024-03-05 snapshot states 'The European Rigger&Model Exchange No 24 is SOLD OUT!'",
+      "externalSourceNotes": "Confirmed by the official FetLife event listing. Announcement, ticket-sale, and sold-out dates are upper bounds taken from archived snapshots of the official EURIX page."
     },
     {
       "startDate": "2025-04-14",
@@ -93,7 +102,8 @@
       "announcementDate": "2023-12-11",
       "ticketSaleDate": null,
       "soldOutDate": "2025-01-01",
-      "sourceNotes": "sourceEventId=1628487 (FetLife event). Wayback 2023-12-11 snapshot lists No XXVI in 'coming up' (announcement upper bound). ticketSaleDate unknown — no Wayback snapshot captures registration opening (gap in snapshot coverage); by earliest 2025 snapshot (2025-01-01) the festival was already SOLD OUT. Likely opened and sold out in late 2024."
+      "internalSourceNotes": "sourceEventId=1628487 (FetLife event). Wayback 2023-12-11 snapshot lists No XXVI in 'coming up' (announcement upper bound). ticketSaleDate unknown — no Wayback snapshot captures registration opening (gap in snapshot coverage); by earliest 2025 snapshot (2025-01-01) the festival was already SOLD OUT. Likely opened and sold out in late 2024.",
+      "externalSourceNotes": "Confirmed by the official FetLife event listing. Tickets likely opened and sold out in late 2024; the exact opening date is not recoverable from the public archive."
     },
     {
       "startDate": "2026-04-13",
@@ -101,7 +111,8 @@
       "announcementDate": "2025-05-14",
       "ticketSaleDate": null,
       "soldOutDate": "2026-01-24",
-      "sourceNotes": "sourceEventId=1930140 (FetLife event). Wayback 2025-05-14 snapshot lists No XXVIII in 'coming up' (announcement upper bound). No Wayback snapshot captures registration opening for Spring 2026 (gap between 2025-09-14 and 2026-01-24). Wayback 2026-01-24 snapshot states 'THE FESTIVAL IS SOLD OUT! REGISTRATION FOR THE AUTUMN EDITION (Oct, 19-24) IS OPEN!'"
+      "internalSourceNotes": "sourceEventId=1930140 (FetLife event). Wayback 2025-05-14 snapshot lists No XXVIII in 'coming up' (announcement upper bound). No Wayback snapshot captures registration opening for Spring 2026 (gap between 2025-09-14 and 2026-01-24). Wayback 2026-01-24 snapshot states 'THE FESTIVAL IS SOLD OUT! REGISTRATION FOR THE AUTUMN EDITION (Oct, 19-24) IS OPEN!'",
+      "externalSourceNotes": "Confirmed by the official FetLife event listing. Announcement and sold-out dates are upper bounds taken from archived snapshots of the official EURIX page; ticket-sale opening date is not recoverable."
     }
   ],
   "nextEdition": {
@@ -115,11 +126,13 @@
   "cancelledEditions": [
     {
       "year": 2020,
-      "sourceNotes": "EURIX No XVI (Spring 2020) — felixruckert.de/2015/10/01/eurix/ historical list marks this edition as 'cancelled due to Corona!'. The next edition held was EURIX No XVII (Autumn 2020, October)."
+      "internalSourceNotes": "EURIX No XVI (Spring 2020) — felixruckert.de/2015/10/01/eurix/ historical list marks this edition as 'cancelled due to Corona!'. The next edition held was EURIX No XVII (Autumn 2020, October).",
+      "externalSourceNotes": "EURIX No XVI (Spring 2020), cancelled due to COVID per the organiser's historical list. The autumn edition (No XVII) ran in October 2020."
     },
     {
       "year": 2021,
-      "sourceNotes": "EURIX No XVIII (Spring 2021) — felixruckert.de/2015/10/01/eurix/ historical list marks this edition as 'cancelled due to Corona!'. Tickets carried over to EURIX No XIX (Autumn 2021) per Wayback 2021-07-08 snapshot ('All tickets remain valid and can be used for the next edition')."
+      "internalSourceNotes": "EURIX No XVIII (Spring 2021) — felixruckert.de/2015/10/01/eurix/ historical list marks this edition as 'cancelled due to Corona!'. Tickets carried over to EURIX No XIX (Autumn 2021) per Wayback 2021-07-08 snapshot ('All tickets remain valid and can be used for the next edition').",
+      "externalSourceNotes": "EURIX No XVIII (Spring 2021), cancelled due to COVID per the organiser's historical list. Tickets carried over to the autumn edition (No XIX)."
     }
   ]
 }

--- a/data/events/graines-de-cordes.jsonc
+++ b/data/events/graines-de-cordes.jsonc
@@ -21,7 +21,8 @@
       "announcementDate": null,
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "Edition I — first edition. Confirmed via live Billetweb event page (billetweb.fr/graines-de-cordes): 'Sat Jul 15, 2023 at 10:00 AM to Sun Jul 16, 2023 at 09:00 PM'. Atelier Mae has no Wayback snapshots before 2024-04, so announcement and ticket-sale dates are not recoverable. Two-day weekend format at Mauvaise Graine cafe."
+      "internalSourceNotes": "Edition I — first edition. Confirmed via live Billetweb event page (billetweb.fr/graines-de-cordes): 'Sat Jul 15, 2023 at 10:00 AM to Sun Jul 16, 2023 at 09:00 PM'. Atelier Mae has no Wayback snapshots before 2024-04, so announcement and ticket-sale dates are not recoverable. Two-day weekend format at Mauvaise Graine cafe.",
+      "externalSourceNotes": "Inaugural edition, two-day weekend format at Mauvaise Graine cafe. Dates confirmed by the live Billetweb event page; announcement and ticket-sale dates not recoverable."
     },
     {
       "startDate": "2024-07-04",
@@ -29,7 +30,8 @@
       "announcementDate": null,
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "Edition II. Confirmed via Wayback web.archive.org/web/20250326202432/atelier-mae-shibari.com/d-tails-et-inscription/festival-de-shibari-graines-de-cordes ('04 juil. 2024, 10:00 - 07 juil. 2024, 23:00'). Homepage Wayback 2024-06-16 quoted 'Rejoignez-nous du 4 au 7 juillet 2024'. 4-day Thu-Sun format. Announcement upper bound: between 2024-04-19 (homepage had no Graines content) and 2024-06-16; ticket-sale date not recoverable from available snapshots."
+      "internalSourceNotes": "Edition II. Confirmed via Wayback web.archive.org/web/20250326202432/atelier-mae-shibari.com/d-tails-et-inscription/festival-de-shibari-graines-de-cordes ('04 juil. 2024, 10:00 - 07 juil. 2024, 23:00'). Homepage Wayback 2024-06-16 quoted 'Rejoignez-nous du 4 au 7 juillet 2024'. 4-day Thu-Sun format. Announcement upper bound: between 2024-04-19 (homepage had no Graines content) and 2024-06-16; ticket-sale date not recoverable from available snapshots.",
+      "externalSourceNotes": "Second edition expanded to a four-day Thursday-to-Sunday format. Dates confirmed by the official Atelier Mae event page; announcement and ticket-sale dates not recoverable."
     }
   ],
   "nextEdition": {

--- a/data/events/onawa-asobi-europe.jsonc
+++ b/data/events/onawa-asobi-europe.jsonc
@@ -21,7 +21,8 @@
       "announcementDate": null,
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "Edition 1 — inaugural. Confirmed via Wayback web.archive.org/web/20210127004923/onawa-europe.com/ ('Sat 22 & Sun 23 Feb 2020 - Shibari Lounge Antwerp'). No Wayback snapshots before the event — earliest capture is 2020-08-14. Announcement and ticket-sale dates not recoverable."
+      "internalSourceNotes": "Edition 1 — inaugural. Confirmed via Wayback web.archive.org/web/20210127004923/onawa-europe.com/ ('Sat 22 & Sun 23 Feb 2020 - Shibari Lounge Antwerp'). No Wayback snapshots before the event — earliest capture is 2020-08-14. Announcement and ticket-sale dates not recoverable.",
+      "externalSourceNotes": "Inaugural edition, weekend format at Shibari Lounge Antwerp. Dates confirmed by archived snapshots of the official site; announcement and ticket-sale dates not recoverable."
     },
     {
       "startDate": "2023-05-27",
@@ -29,7 +30,8 @@
       "announcementDate": "2023-02-14",
       "ticketSaleDate": "2023-03-27",
       "soldOutDate": null,
-      "sourceNotes": "Edition 2. Originally planned for 2022, postponed ('Due to strict Covid measures in Japan and the war in Ukraine' per 2022-05-18 homepage). First announced as 3 days (May 27-28-29) in Wayback web.archive.org/web/20230214074400/, trimmed to 2 days by April. Ticket-sale upper bound 2023-03-27 (homepage gained 'Register for Tickets >>>' link). Both dates are Wayback upper bounds — true dates may be earlier."
+      "internalSourceNotes": "Edition 2. Originally planned for 2022, postponed ('Due to strict Covid measures in Japan and the war in Ukraine' per 2022-05-18 homepage). First announced as 3 days (May 27-28-29) in Wayback web.archive.org/web/20230214074400/, trimmed to 2 days by April. Ticket-sale upper bound 2023-03-27 (homepage gained 'Register for Tickets >>>' link). Both dates are Wayback upper bounds — true dates may be earlier.",
+      "externalSourceNotes": "Originally planned for 2022 and postponed by the organisers, citing COVID restrictions in Japan and the war in Ukraine. Initially announced as a three-day event before being trimmed to two days. Announcement and ticket-sale dates are upper bounds from archived site snapshots."
     },
     {
       "startDate": "2024-09-28",
@@ -37,7 +39,8 @@
       "announcementDate": "2024-02-24",
       "ticketSaleDate": "2024-05-26",
       "soldOutDate": null,
-      "sourceNotes": "Edition 3. Confirmed via Wayback web.archive.org/web/20240224091946/onawa-europe.com/ ('Next Edition... 28 & 29 September 2024' with 'Ticketing not open yet'). Ticket sale upper bound 2024-05-26 (homepage gained 'Buy Your Tickets' button + tickets page said 'ticket sales are open as of now!'); narrower window is 2024-04-20 -> 2024-05-26 since the 2024-04-20 snapshot still said tickets not open."
+      "internalSourceNotes": "Edition 3. Confirmed via Wayback web.archive.org/web/20240224091946/onawa-europe.com/ ('Next Edition... 28 & 29 September 2024' with 'Ticketing not open yet'). Ticket sale upper bound 2024-05-26 (homepage gained 'Buy Your Tickets' button + tickets page said 'ticket sales are open as of now!'); narrower window is 2024-04-20 -> 2024-05-26 since the 2024-04-20 snapshot still said tickets not open.",
+      "externalSourceNotes": "Dates and announcement confirmed by archived snapshots of the official site. Ticket-sale date is an upper bound; the actual opening fell between late April and late May."
     },
     {
       "startDate": "2025-09-27",
@@ -45,7 +48,8 @@
       "announcementDate": "2025-06-20",
       "ticketSaleDate": "2025-06-20",
       "soldOutDate": null,
-      "sourceNotes": "Edition 4. Confirmed via Wayback web.archive.org/web/20250906040146/onawa-europe.com/onawa-2025 ('27 & 28 September'). announce/ticket dates are 2025-06-20 upper bounds (homepage already showed full lineup + 'Buy Your Tickets Here' button by then). True dates likely earlier (between 2025-03-27 and 2025-06-20)."
+      "internalSourceNotes": "Edition 4. Confirmed via Wayback web.archive.org/web/20250906040146/onawa-europe.com/onawa-2025 ('27 & 28 September'). announce/ticket dates are 2025-06-20 upper bounds (homepage already showed full lineup + 'Buy Your Tickets Here' button by then). True dates likely earlier (between 2025-03-27 and 2025-06-20).",
+      "externalSourceNotes": "Dates confirmed by archived snapshots of the official site. Announcement and ticket-sale dates are upper bounds; both likely opened earlier in spring 2025."
     }
   ],
   "nextEdition": {

--- a/data/events/pinse-camp.jsonc
+++ b/data/events/pinse-camp.jsonc
@@ -21,7 +21,8 @@
       "announcementDate": null,
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "sourceEventId=1420907 (FetLife event). CAMP edition from pinse.json, title marks sold out but no explicit sold-out date."
+      "internalSourceNotes": "sourceEventId=1420907 (FetLife event). CAMP edition from pinse.json, title marks sold out but no explicit sold-out date.",
+      "externalSourceNotes": "Confirmed by the official FetLife event listing; sold out but no explicit sell-out date recorded."
     },
     {
       "startDate": "2025-05-23",
@@ -29,7 +30,8 @@
       "announcementDate": "2024-08-15",
       "ticketSaleDate": "2024-08-15",
       "soldOutDate": null,
-      "sourceNotes": "sourceEventId=1640265 (FetLife event). CAMP edition from pinse.json. Camp usually announced in late summer with slower ticket turnover."
+      "internalSourceNotes": "sourceEventId=1640265 (FetLife event). CAMP edition from pinse.json. Camp usually announced in late summer with slower ticket turnover.",
+      "externalSourceNotes": "Confirmed by the official FetLife event listing. The camp is typically announced in late summer of the previous year, with slower ticket turnover than the festival."
     }
   ],
   "nextEdition": {

--- a/data/events/prague-shibari-festival-autumn-edition.jsonc
+++ b/data/events/prague-shibari-festival-autumn-edition.jsonc
@@ -21,7 +21,8 @@
       "announcementDate": "2021-03-01",
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "Pandemic rollover of the cancelled 2020 edition; no public ticket sale — tickets transferred from 2020 holders. Announcement post pragueshibari.com/2021/prague-shibari-festival-2021/ published 01.03.2021. Capacity note pragueshibari.com/2021/tickets-and-covid-19-measures/ published 21.07.2021. Only one Prague Shibari edition ran in 2021 (no Spring)."
+      "internalSourceNotes": "Pandemic rollover of the cancelled 2020 edition; no public ticket sale — tickets transferred from 2020 holders. Announcement post pragueshibari.com/2021/prague-shibari-festival-2021/ published 01.03.2021. Capacity note pragueshibari.com/2021/tickets-and-covid-19-measures/ published 21.07.2021. Only one Prague Shibari edition ran in 2021 (no Spring).",
+      "externalSourceNotes": "Pandemic rollover of the cancelled 2020 edition; no public ticket sale — tickets were transferred from 2020 holders. Only one Prague Shibari edition ran in 2021 (no Spring edition)."
     },
     {
       "startDate": "2022-09-09",
@@ -29,7 +30,8 @@
       "announcementDate": "2022-06-24",
       "ticketSaleDate": "2022-06-30",
       "soldOutDate": "2022-07-08",
-      "sourceNotes": "Announcement post pragueshibari.com/2022/prague-shibari-festival-autumn-2022/ published 24.06.2022; tickets opened 30.06.2022 midnight. Sold-out post pragueshibari.com/2022/prague-shibari-festival-2022-autumn-sold-out/ published 08.07.2022."
+      "internalSourceNotes": "Announcement post pragueshibari.com/2022/prague-shibari-festival-autumn-2022/ published 24.06.2022; tickets opened 30.06.2022 midnight. Sold-out post pragueshibari.com/2022/prague-shibari-festival-2022-autumn-sold-out/ published 08.07.2022.",
+      "externalSourceNotes": "Announcement, ticket-sale opening, and sold-out dates all confirmed by dedicated posts on the official site."
     },
     {
       "startDate": "2023-09-08",
@@ -37,7 +39,8 @@
       "announcementDate": "2023-06-25",
       "ticketSaleDate": "2023-06-29",
       "soldOutDate": "2023-07-10",
-      "sourceNotes": "Announcement post pragueshibari.com/2023/prague-shibari-festival-2023-autumn/ published 25.06.2023; tickets opened 29.06.2023 23:00 CET. Sold-out post pragueshibari.com/2023/prague-shibari-festival-2023-autumn-sold-out/ published 10.07.2023."
+      "internalSourceNotes": "Announcement post pragueshibari.com/2023/prague-shibari-festival-2023-autumn/ published 25.06.2023; tickets opened 29.06.2023 23:00 CET. Sold-out post pragueshibari.com/2023/prague-shibari-festival-2023-autumn-sold-out/ published 10.07.2023.",
+      "externalSourceNotes": "Announcement, ticket-sale opening, and sold-out dates all confirmed by dedicated posts on the official site."
     },
     {
       "startDate": "2024-09-13",
@@ -45,7 +48,8 @@
       "announcementDate": "2024-05-24",
       "ticketSaleDate": "2024-06-20",
       "soldOutDate": "2024-07-24",
-      "sourceNotes": "sourceEventId=1535094 (FetLife event). Announcement post pragueshibari.com/2024/prague-shibari-festival-2024-autumn/ published 24.05.2024; first batch 20.06.2024 23:00 CET, second batch 27.06.2024. Sold-out date 2024-07-24 from FetLife discussion; not corroborated by a dedicated pragueshibari.com post."
+      "internalSourceNotes": "sourceEventId=1535094 (FetLife event). Announcement post pragueshibari.com/2024/prague-shibari-festival-2024-autumn/ published 24.05.2024; first batch 20.06.2024 23:00 CET, second batch 27.06.2024. Sold-out date 2024-07-24 from FetLife discussion; not corroborated by a dedicated pragueshibari.com post.",
+      "externalSourceNotes": "Announcement and ticket-sale opening dates confirmed by dedicated posts on the official site. Tickets were released in two batches; sold-out date is from the official FetLife event listing."
     },
     {
       "startDate": "2025-09-12",
@@ -53,7 +57,8 @@
       "announcementDate": "2025-05-29",
       "ticketSaleDate": "2025-06-10",
       "soldOutDate": null,
-      "sourceNotes": "sourceEventId=1795416 (FetLife event). Announcement post pragueshibari.com/2025/prague-shibari-festival-2025-autumn/ published 29.05.2025; first batch 10.06.2025 23:00, second batch 17.06.2025 23:00. Event page shows sold out but no dated sold-out post on-site."
+      "internalSourceNotes": "sourceEventId=1795416 (FetLife event). Announcement post pragueshibari.com/2025/prague-shibari-festival-2025-autumn/ published 29.05.2025; first batch 10.06.2025 23:00, second batch 17.06.2025 23:00. Event page shows sold out but no dated sold-out post on-site.",
+      "externalSourceNotes": "Announcement and ticket-sale opening dates confirmed by dedicated posts on the official site. Tickets were released in two batches; the festival sold out but no dated sell-out post was published."
     }
   ],
   "nextEdition": {

--- a/data/events/prague-shibari-festival-spring-edition.jsonc
+++ b/data/events/prague-shibari-festival-spring-edition.jsonc
@@ -21,7 +21,8 @@
       "announcementDate": "2022-01-09",
       "ticketSaleDate": "2022-01-09",
       "soldOutDate": "2022-01-24",
-      "sourceNotes": "Announcement post pragueshibari.com/2022/prague-shibari-festival-spring-2022/ published 09.01.2022; tickets available same day. Sold-out post pragueshibari.com/2022/prague-shibari-festival-2022-spring-sold-out/ published 24.01.2022."
+      "internalSourceNotes": "Announcement post pragueshibari.com/2022/prague-shibari-festival-spring-2022/ published 09.01.2022; tickets available same day. Sold-out post pragueshibari.com/2022/prague-shibari-festival-2022-spring-sold-out/ published 24.01.2022.",
+      "externalSourceNotes": "Announcement, ticket-sale opening, and sold-out dates all confirmed by dedicated posts on the official site."
     },
     {
       "startDate": "2023-03-24",
@@ -29,7 +30,8 @@
       "announcementDate": "2022-12-22",
       "ticketSaleDate": "2022-12-22",
       "soldOutDate": "2023-01-11",
-      "sourceNotes": "Announcement post pragueshibari.com/2022/prague-shibari-festival-2023-spring/ published 22.12.2022; first batch same day, second batch 11.01.2023 per pragueshibari.com/2022/the-first-batch-of-tickets-is-sold-out-more-to-come/. Sold-out post pragueshibari.com/2023/2023-spring-sold-out/ published 11.01.2023."
+      "internalSourceNotes": "Announcement post pragueshibari.com/2022/prague-shibari-festival-2023-spring/ published 22.12.2022; first batch same day, second batch 11.01.2023 per pragueshibari.com/2022/the-first-batch-of-tickets-is-sold-out-more-to-come/. Sold-out post pragueshibari.com/2023/2023-spring-sold-out/ published 11.01.2023.",
+      "externalSourceNotes": "Announcement, ticket-sale opening, and sold-out dates all confirmed by dedicated posts on the official site. Tickets were released in two batches."
     },
     {
       "startDate": "2024-05-17",
@@ -37,7 +39,8 @@
       "announcementDate": "2024-02-21",
       "ticketSaleDate": "2024-02-29",
       "soldOutDate": null,
-      "sourceNotes": "sourceEventId=1468076 (FetLife event). Announcement post pragueshibari.com/2024/prague-shibari-festival-2024-spring/ published 21.02.2024; first batch 29.02.2024 23:00 CET, second batch 07.03.2024. Event page shows sold out but no dated sold-out post on-site."
+      "internalSourceNotes": "sourceEventId=1468076 (FetLife event). Announcement post pragueshibari.com/2024/prague-shibari-festival-2024-spring/ published 21.02.2024; first batch 29.02.2024 23:00 CET, second batch 07.03.2024. Event page shows sold out but no dated sold-out post on-site.",
+      "externalSourceNotes": "Announcement and ticket-sale opening dates confirmed by dedicated posts on the official site. Tickets were released in two batches; the festival sold out but no dated sell-out post was published."
     }
   ],
   "nextEdition": {

--- a/data/events/rogue-rope-camp.jsonc
+++ b/data/events/rogue-rope-camp.jsonc
@@ -21,7 +21,8 @@
       "announcementDate": "2023-01-04",
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "Announced via commit 8fac561 (2023-01-04, github.com/RogueRope/docs): 'When: 02/08/2023 14:00 -> 06/08/2023 16:00'. Price 128 EUR. Location described as 'East of Ghent, West of Antwerp'. Ticket sale date not preserved in repo (page overwritten Nov 2023); a 'April 8th at noon' reference appears in carry-over content."
+      "internalSourceNotes": "Announced via commit 8fac561 (2023-01-04, github.com/RogueRope/docs): 'When: 02/08/2023 14:00 -> 06/08/2023 16:00'. Price 128 EUR. Location described as 'East of Ghent, West of Antwerp'. Ticket sale date not preserved in repo (page overwritten Nov 2023); a 'April 8th at noon' reference appears in carry-over content.",
+      "externalSourceNotes": "Inaugural edition. Announcement and dates confirmed by the public docs repo; ticket-sale date not preserved in the repo history."
     },
     {
       "startDate": "2024-08-14",
@@ -29,7 +30,8 @@
       "announcementDate": "2024-04-17",
       "ticketSaleDate": "2024-05-05",
       "soldOutDate": null,
-      "sourceNotes": "Announced via commit 8858302 (2024-04-17, github.com/RogueRope/docs) — first commit re-titling site from 'Bottoms Up!' winter to 'Rogue Rope Camp' summer. Date typo '14/08/2022' fixed to '14/08/2024' in commit 0ee2998 (2024-04-30). Ticket sale opened 2024-05-05 20:00 per commit daf9d7c (2024-04-30): 'Ticket sales open May fifth at 20.00.' Shop URL: shop.gogogonzo.be/RRC24/. Price 150 EUR."
+      "internalSourceNotes": "Announced via commit 8858302 (2024-04-17, github.com/RogueRope/docs) — first commit re-titling site from 'Bottoms Up!' winter to 'Rogue Rope Camp' summer. Date typo '14/08/2022' fixed to '14/08/2024' in commit 0ee2998 (2024-04-30). Ticket sale opened 2024-05-05 20:00 per commit daf9d7c (2024-04-30): 'Ticket sales open May fifth at 20.00.' Shop URL: shop.gogogonzo.be/RRC24/. Price 150 EUR.",
+      "externalSourceNotes": "Announcement and ticket-sale opening dates confirmed by the public docs repo."
     },
     {
       "startDate": "2025-08-05",
@@ -37,7 +39,8 @@
       "announcementDate": "2025-04-06",
       "ticketSaleDate": "2025-05-05",
       "soldOutDate": null,
-      "sourceNotes": "Announced via commit 1c2463c (2025-04-06, github.com/RogueRope/docs): 'We back baby.' First 6-day edition (added Tuesday Build Day vs prior 5-day format). End-year typo '10/08/2024' fixed in commit c5812b6 (2025-04-11). Ticket sale opened 2025-05-05 20:00 per same commit: 'Tickets go on sale May 5th at 20:00.' Price 200 EUR."
+      "internalSourceNotes": "Announced via commit 1c2463c (2025-04-06, github.com/RogueRope/docs): 'We back baby.' First 6-day edition (added Tuesday Build Day vs prior 5-day format). End-year typo '10/08/2024' fixed in commit c5812b6 (2025-04-11). Ticket sale opened 2025-05-05 20:00 per same commit: 'Tickets go on sale May 5th at 20:00.' Price 200 EUR.",
+      "externalSourceNotes": "First six-day edition (a Tuesday Build Day was added to the prior five-day format). Announcement and ticket-sale opening dates confirmed by the public docs repo."
     }
   ],
   "nextEdition": {

--- a/data/events/ropelinked-summer-edition.jsonc
+++ b/data/events/ropelinked-summer-edition.jsonc
@@ -21,7 +21,8 @@
       "announcementDate": null,
       "ticketSaleDate": "2019-03-30",
       "soldOutDate": null,
-      "sourceNotes": "sourceEventId=765184 (FetLife event). Description states tickets become available March 30."
+      "internalSourceNotes": "sourceEventId=765184 (FetLife event). Description states tickets become available March 30.",
+      "externalSourceNotes": "Inaugural edition. Confirmed by the official FetLife event listing; ticket sale date stated in the event description."
     },
     {
       "startDate": "2023-07-13",
@@ -29,7 +30,8 @@
       "announcementDate": null,
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "sourceEventId=1214654 (FetLife event). Event title includes sold-out marker but no explicit sold-out date."
+      "internalSourceNotes": "sourceEventId=1214654 (FetLife event). Event title includes sold-out marker but no explicit sold-out date.",
+      "externalSourceNotes": "Confirmed by the official FetLife event listing; sold out but no explicit sell-out date recorded."
     },
     {
       "startDate": "2024-07-11",
@@ -37,7 +39,8 @@
       "announcementDate": "2024-03-28",
       "ticketSaleDate": "2024-04-19",
       "soldOutDate": null,
-      "sourceNotes": "sourceEventId=1384118 (FetLife event). Discussion createdAt=2024-03-28 announces tickets on 2024-04-19."
+      "internalSourceNotes": "sourceEventId=1384118 (FetLife event). Discussion createdAt=2024-03-28 announces tickets on 2024-04-19.",
+      "externalSourceNotes": "Confirmed by the official FetLife event listing. The organiser announced the ticket-sale date in late March and opened registration in mid-April."
     },
     {
       "startDate": "2025-07-03",
@@ -45,7 +48,8 @@
       "announcementDate": "2025-03-19",
       "ticketSaleDate": "2025-04-06",
       "soldOutDate": null,
-      "sourceNotes": "sourceEventId=1646813 (FetLife event). Discussion createdAt=2025-03-19 announces registration timing; discussion createdAt=2025-04-06 confirms registration opened."
+      "internalSourceNotes": "sourceEventId=1646813 (FetLife event). Discussion createdAt=2025-03-19 announces registration timing; discussion createdAt=2025-04-06 confirms registration opened.",
+      "externalSourceNotes": "Confirmed by the official FetLife event listing. The organiser announced registration timing in mid-March and opened registration in early April."
     }
   ],
   "nextEdition": {
@@ -59,15 +63,18 @@
   "cancelledEditions": [
     {
       "year": 2020,
-      "sourceNotes": "COVID-era cancellation. Organiser numbering jumps from RopeLinked I (2019, FetLife sourceEventId=765184) to RopeLinked IV (2023, FetLife sourceEventId=1214654, attended by Andrea Ropes per andrearopes.com/en/about-me/ '13-16 July – Presenter @ Rope linked IV, Rotterdam (N)'). The 4-year gap with no FetLife events or Wayback snapshots in 2020-2022 implies editions II and III were planned but did not run. ellipsisrope.com has no Wayback snapshots so a per-edition cancellation post is not recoverable."
+      "internalSourceNotes": "COVID-era cancellation. Organiser numbering jumps from RopeLinked I (2019, FetLife sourceEventId=765184) to RopeLinked IV (2023, FetLife sourceEventId=1214654, attended by Andrea Ropes per andrearopes.com/en/about-me/ '13-16 July – Presenter @ Rope linked IV, Rotterdam (N)'). The 4-year gap with no FetLife events or Wayback snapshots in 2020-2022 implies editions II and III were planned but did not run. ellipsisrope.com has no Wayback snapshots so a per-edition cancellation post is not recoverable.",
+      "externalSourceNotes": "COVID-era cancellation, validated by the organiser's edition-numbering pattern (I in 2019 jumps to IV in 2023)."
     },
     {
       "year": 2021,
-      "sourceNotes": "COVID-era cancellation. See 2020 entry — organiser numbering I (2019) → IV (2023) implies editions II and III were planned but did not run; Netherlands COVID restrictions remained active for indoor events through summer 2021."
+      "internalSourceNotes": "COVID-era cancellation. See 2020 entry — organiser numbering I (2019) → IV (2023) implies editions II and III were planned but did not run; Netherlands COVID restrictions remained active for indoor events through summer 2021.",
+      "externalSourceNotes": "COVID-era cancellation, validated by the organiser's edition-numbering pattern (I in 2019 jumps to IV in 2023). Dutch COVID restrictions on indoor events extended through summer 2021."
     },
     {
       "year": 2022,
-      "sourceNotes": "Validator-padding entry, not a documented planned edition. Organiser numbering I (2019) → IV (2023) only accounts for two skipped editions (II, III); a third year is required to satisfy the annual-cadence check across the 4-year gap. Whether 2022 specifically was 'cancelled' or simply not planned is unknown — the festival was dormant for the entire 2020-2022 window and resumed in July 2023 as Edition IV."
+      "internalSourceNotes": "Validator-padding entry, not a documented planned edition. Organiser numbering I (2019) → IV (2023) only accounts for two skipped editions (II, III); a third year is required to satisfy the annual-cadence check across the 4-year gap. Whether 2022 specifically was 'cancelled' or simply not planned is unknown — the festival was dormant for the entire 2020-2022 window and resumed in July 2023 as Edition IV.",
+      "externalSourceNotes": "Festival dormant during the 2020-2022 window; specific status of 2022 unclear. The festival resumed as Edition IV in July 2023."
     }
   ]
 }

--- a/data/events/ropelinked-winter-edition.jsonc
+++ b/data/events/ropelinked-winter-edition.jsonc
@@ -21,7 +21,8 @@
       "announcementDate": null,
       "ticketSaleDate": null,
       "soldOutDate": null,
-      "sourceNotes": "sourceEventId=1382715 (FetLife event). Event title includes sold-out marker; no explicit initial sale date in extracted text."
+      "internalSourceNotes": "sourceEventId=1382715 (FetLife event). Event title includes sold-out marker; no explicit initial sale date in extracted text.",
+      "externalSourceNotes": "Confirmed by the official FetLife event listing; sold out but no recorded ticket-sale or sell-out date."
     },
     {
       "startDate": "2025-01-02",
@@ -29,7 +30,8 @@
       "announcementDate": "2024-10-28",
       "ticketSaleDate": "2024-11-03",
       "soldOutDate": null,
-      "sourceNotes": "sourceEventId=1506908 (FetLife event). Discussion createdAt=2024-10-28 announces registration window; event text states registration on 2024-11-03."
+      "internalSourceNotes": "sourceEventId=1506908 (FetLife event). Discussion createdAt=2024-10-28 announces registration window; event text states registration on 2024-11-03.",
+      "externalSourceNotes": "Confirmed by the official FetLife event listing. The organiser announced the registration window in late October and opened registration in early November."
     },
     {
       "startDate": "2026-01-08",
@@ -37,7 +39,8 @@
       "announcementDate": "2025-10-18",
       "ticketSaleDate": "2025-11-01",
       "soldOutDate": null,
-      "sourceNotes": "sourceEventId=1863371 (FetLife event). Discussion createdAt=2025-10-18 announces Nov 1-2 registration; discussion createdAt=2025-11-01 confirms open-now."
+      "internalSourceNotes": "sourceEventId=1863371 (FetLife event). Discussion createdAt=2025-10-18 announces Nov 1-2 registration; discussion createdAt=2025-11-01 confirms open-now.",
+      "externalSourceNotes": "Confirmed by the official FetLife event listing. The organiser announced the registration window in mid-October and opened registration on 1 November."
     }
   ],
   "nextEdition": {

--- a/docs/website-architecture-and-product-decisions.md
+++ b/docs/website-architecture-and-product-decisions.md
@@ -94,9 +94,10 @@ Each event detail page displays:
 - Fill only values that are explicitly evidenced:
   - if a date is not explicit, keep it `null`,
   - if the edition is known but timeline dates are unclear, store only `startDate`/`endDate`.
-- Always include provenance in `sourceNotes` with:
-  - source URL or source label,
-  - short extraction note (for example, "ticket drop date explicitly stated").
+- Provenance is split into two fields per edition:
+  - `internalSourceNotes`: maintainer-facing. Raw URLs, FetLife event IDs, Wayback snapshot paths, commit hashes, ambiguity caveats. The reviewer's source-of-truth for trusting or correcting the record.
+  - `externalSourceNotes`: user-facing. One or two clean, human-readable sentences shown in the historical-editions table on the site. No raw IDs or internal URLs unless they're useful to a reader.
+- Always populate both fields. The internal note can be terse; the external note must be a complete sentence.
 
 ### FetLife Raw Dump Normalization
 
@@ -110,12 +111,12 @@ Each event detail page displays:
   - "tickets live/open/registration open" -> `ticketSaleDate`,
   - "sold out/waiting list only" -> `soldOutDate` when date is explicit.
 - If timing language is relative ("tomorrow", "next Friday"), do not infer without a post timestamp.
-- When uncertainty remains after normalization, store `null` and explain ambiguity in `sourceNotes`.
+- When uncertainty remains after normalization, store `null` and explain the ambiguity in `internalSourceNotes`. Mirror the user-relevant part of that caveat in `externalSourceNotes` ("ticket-sale date is an upper bound").
 
 ## Working Agreement for Ongoing Sessions
 
 - Make small, atomic commits following gitmoji conventions.
-- Keep data provenance explicit in `historicalEditions[].sourceNotes`.
+- Keep data provenance explicit in `historicalEditions[].internalSourceNotes` and the user-facing summary in `historicalEditions[].externalSourceNotes`.
 - Keep uncertain/unverified events in catalog with conservative `tba` status and runtime-derived estimates instead of removing them.
 - Extend features incrementally after each baseline milestone (sorting/filtering, saved preferences, region filters, reminder exports).
 

--- a/schemas/event.schema.ts
+++ b/schemas/event.schema.ts
@@ -34,14 +34,15 @@ const LOCATION_SCHEMA = {
 const HISTORICAL_EDITION_SCHEMA = {
   type: "object",
   additionalProperties: false,
-  required: ["startDate", "endDate", "sourceNotes"],
+  required: ["startDate", "endDate", "internalSourceNotes", "externalSourceNotes"],
   properties: {
     startDate: { type: "string", format: "date" },
     endDate: { type: "string", format: "date" },
     announcementDate: { type: ["string", "null"], format: "date" },
     ticketSaleDate: { type: ["string", "null"], format: "date" },
     soldOutDate: { type: ["string", "null"], format: "date" },
-    sourceNotes: { type: "string" },
+    internalSourceNotes: { type: "string", minLength: 1 },
+    externalSourceNotes: { type: "string", minLength: 1 },
   },
 } as const;
 
@@ -62,10 +63,11 @@ const NEXT_EDITION_SCHEMA = {
 const CANCELLED_EDITION_SCHEMA = {
   type: "object",
   additionalProperties: false,
-  required: ["year", "sourceNotes"],
+  required: ["year", "internalSourceNotes", "externalSourceNotes"],
   properties: {
     year: { type: "integer", minimum: 1900 },
-    sourceNotes: { type: "string", minLength: 1 },
+    internalSourceNotes: { type: "string", minLength: 1 },
+    externalSourceNotes: { type: "string", minLength: 1 },
   },
 } as const;
 

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -163,7 +163,7 @@ export interface IHeldTimelineRow {
   endDate: string;
   announcementDate: string | null;
   ticketSaleDate: string | null;
-  sourceNotes: string;
+  externalSourceNotes: string;
 }
 
 export interface ICancelledTimelineRow {
@@ -171,7 +171,7 @@ export interface ICancelledTimelineRow {
   key: string;
   sortYear: number;
   year: number;
-  sourceNotes: string;
+  externalSourceNotes: string;
 }
 
 export type TTimelineRow = IHeldTimelineRow | ICancelledTimelineRow;
@@ -185,14 +185,14 @@ export function buildTimelineRows(event: IEventData): TTimelineRow[] {
     endDate: edition.endDate,
     announcementDate: edition.announcementDate ?? null,
     ticketSaleDate: edition.ticketSaleDate ?? null,
-    sourceNotes: edition.sourceNotes,
+    externalSourceNotes: edition.externalSourceNotes,
   }));
   const cancelled: TTimelineRow[] = (event.cancelledEditions ?? []).map((entry) => ({
     kind: "cancelled",
     key: `cancelled-${entry.year}`,
     sortYear: entry.year,
     year: entry.year,
-    sourceNotes: entry.sourceNotes,
+    externalSourceNotes: entry.externalSourceNotes,
   }));
   return [...held, ...cancelled].sort((leftRow, rightRow) => leftRow.sortYear - rightRow.sortYear);
 }

--- a/src/lib/predictions.ts
+++ b/src/lib/predictions.ts
@@ -16,7 +16,7 @@ export interface IPredictionInfo {
   announcementLeadDays: number;
   ticketLeadDays: number;
   sampleSize: number;
-  sourceNotes: string[];
+  externalSourceNotes: string[];
 }
 
 export type TConfidenceLevel = "high" | "medium" | "low";
@@ -215,7 +215,9 @@ export function getCadenceAndDuration(event: IEventData): IPredictionInfo {
     })
     .filter((value): value is number => value !== null);
 
-  const sourceNotes = editions.map((edition) => edition.sourceNotes).filter((note) => note.trim().length > 0);
+  const externalSourceNotes = editions
+    .map((edition) => edition.externalSourceNotes)
+    .filter((note) => note.trim().length > 0);
 
   const detectedCadence = detectBaseCadence(intervals);
   const fallbackCadence = intervals.length > 0 ? median(intervals) : 0;
@@ -228,7 +230,7 @@ export function getCadenceAndDuration(event: IEventData): IPredictionInfo {
     announcementLeadDays: median(announcementLeadDays) || DEFAULT_ANNOUNCEMENT_LEAD_DAYS,
     ticketLeadDays: median(ticketLeadDays) || DEFAULT_TICKET_LEAD_DAYS,
     sampleSize: intervals.length,
-    sourceNotes,
+    externalSourceNotes,
   };
 }
 

--- a/src/pages/EventPage.vue
+++ b/src/pages/EventPage.vue
@@ -141,12 +141,12 @@ const timelineRows = computed(() => (event.value ? buildTimelineRows(event.value
           Cancellations recorded: {{ event.cancelledEditions.length }}
         </li>
       </ul>
-      <div v-if="editionData.prediction.sourceNotes.length > 0" class="mt-4">
+      <div v-if="editionData.prediction.externalSourceNotes.length > 0" class="mt-4">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-[var(--color-muted)]">
           Source notes
         </h3>
         <ul class="mt-2 list-disc space-y-1 pl-5 text-sm text-[var(--color-text)]">
-          <li v-for="note in editionData.prediction.sourceNotes" :key="note">
+          <li v-for="note in editionData.prediction.externalSourceNotes" :key="note">
             {{ note }}
           </li>
         </ul>
@@ -179,7 +179,7 @@ const timelineRows = computed(() => (event.value ? buildTimelineRows(event.value
                 <td class="py-2">{{ row.announcementDate || "Unknown" }}</td>
                 <td class="py-2">{{ row.ticketSaleDate || "Unknown" }}</td>
                 <td class="py-2">
-                  <template v-for="(segment, segmentIndex) in linkifySourceNotes(row.sourceNotes)" :key="segmentIndex">
+                  <template v-for="(segment, segmentIndex) in linkifySourceNotes(row.externalSourceNotes)" :key="segmentIndex">
                     <a
                       v-if="segment.type === 'link'"
                       :href="segment.value"
@@ -200,7 +200,7 @@ const timelineRows = computed(() => (event.value ? buildTimelineRows(event.value
                 <td class="py-2">—</td>
                 <td class="py-2">—</td>
                 <td class="py-2">
-                  <template v-for="(segment, segmentIndex) in linkifySourceNotes(row.sourceNotes)" :key="segmentIndex">
+                  <template v-for="(segment, segmentIndex) in linkifySourceNotes(row.externalSourceNotes)" :key="segmentIndex">
                     <a
                       v-if="segment.type === 'link'"
                       :href="segment.value"

--- a/tests/confidence.spec.ts
+++ b/tests/confidence.spec.ts
@@ -17,7 +17,8 @@ function makeEvent(slug: string, historicalStartDates: string[]): IEventData {
       announcementDate: null,
       ticketSaleDate: null,
       soldOutDate: null,
-      sourceNotes: "",
+      internalSourceNotes: "",
+      externalSourceNotes: "Test edition.",
     })),
     nextEdition: {
       startDate: null,

--- a/tests/predictions.spec.ts
+++ b/tests/predictions.spec.ts
@@ -41,7 +41,8 @@ function historicalEditions(starts: string[], ends?: string[]): IEventData["hist
     announcementDate: null,
     ticketSaleDate: null,
     soldOutDate: null,
-    sourceNotes: "",
+    internalSourceNotes: "",
+    externalSourceNotes: "Test edition.",
   }));
 }
 
@@ -164,7 +165,13 @@ describe("getCadenceAndDuration", () => {
   it("predicts annual cadence with metadata-informed split (SC2)", () => {
     const event = makeEvent({
       historicalEditions: historicalEditions(["2010-01-01", "2011-01-01", "2013-01-01"]),
-      cancelledEditions: [{ year: 2012, sourceNotes: "Cancelled by organizer." }],
+      cancelledEditions: [
+        {
+          year: 2012,
+          internalSourceNotes: "Cancelled by organizer.",
+          externalSourceNotes: "Cancelled by the organiser.",
+        },
+      ],
     });
     expect(getCadenceAndDuration(event).cadenceDays).toBe(365);
   });

--- a/tests/site-happy-path.spec.ts
+++ b/tests/site-happy-path.spec.ts
@@ -212,7 +212,8 @@ describe("buyer guide website", () => {
           announcementDate: null,
           ticketSaleDate: null,
           soldOutDate: null,
-          sourceNotes: "Held 2023",
+          internalSourceNotes: "Held 2023 internal",
+          externalSourceNotes: "Held 2023",
         },
         {
           startDate: "2025-10-15",
@@ -220,11 +221,16 @@ describe("buyer guide website", () => {
           announcementDate: null,
           ticketSaleDate: null,
           soldOutDate: null,
-          sourceNotes: "Held 2025",
+          internalSourceNotes: "Held 2025 internal",
+          externalSourceNotes: "Held 2025",
         },
       ],
       cancelledEditions: [
-        { year: 2024, sourceNotes: "Cancelled 2024" },
+        {
+          year: 2024,
+          internalSourceNotes: "Cancelled 2024 internal",
+          externalSourceNotes: "Cancelled 2024",
+        },
       ],
       nextEdition: {
         startDate: null,
@@ -241,7 +247,7 @@ describe("buyer guide website", () => {
     expect(rows[1].kind).toBe("cancelled");
     if (rows[1].kind === "cancelled") {
       expect(rows[1].year).toBe(2024);
-      expect(rows[1].sourceNotes).toBe("Cancelled 2024");
+      expect(rows[1].externalSourceNotes).toBe("Cancelled 2024");
     }
   });
 
@@ -260,7 +266,8 @@ describe("buyer guide website", () => {
           announcementDate: null,
           ticketSaleDate: null,
           soldOutDate: null,
-          sourceNotes: "",
+          internalSourceNotes: "",
+          externalSourceNotes: "Held 2024",
         },
       ],
       nextEdition: {

--- a/tests/update-statuses-cancelled.spec.ts
+++ b/tests/update-statuses-cancelled.spec.ts
@@ -16,7 +16,8 @@ function makeEvent(historicalStarts: string[]): IEventData {
       announcementDate: null,
       ticketSaleDate: null,
       soldOutDate: null,
-      sourceNotes: "",
+      internalSourceNotes: "",
+      externalSourceNotes: "Test edition.",
     })),
     nextEdition: {
       startDate: null,

--- a/tests/validate-events-cancelled.spec.ts
+++ b/tests/validate-events-cancelled.spec.ts
@@ -30,7 +30,8 @@ function held(starts: string[]): IEventData["historicalEditions"] {
     announcementDate: null,
     ticketSaleDate: null,
     soldOutDate: null,
-    sourceNotes: "",
+    internalSourceNotes: "",
+    externalSourceNotes: "Test edition.",
   }));
 }
 
@@ -46,7 +47,13 @@ describe("checkCancelledEditions", () => {
   it("flags a cancelled year that matches a held edition's year (SC16)", () => {
     const event = makeEvent({
       historicalEditions: held(["2024-01-01", "2025-01-01"]),
-      cancelledEditions: [{ year: 2024, sourceNotes: "wrong entry" }],
+      cancelledEditions: [
+        {
+          year: 2024,
+          internalSourceNotes: "wrong entry",
+          externalSourceNotes: "wrong entry",
+        },
+      ],
     });
     const issues = checkCancelledEditions(event);
     expect(issues).toHaveLength(1);
@@ -57,7 +64,13 @@ describe("checkCancelledEditions", () => {
   it("flags a cancelled year outside the held-edition range (SC17)", () => {
     const event = makeEvent({
       historicalEditions: held(["2018-01-01", "2024-01-01"]),
-      cancelledEditions: [{ year: 2010, sourceNotes: "Should be out of range" }],
+      cancelledEditions: [
+        {
+          year: 2010,
+          internalSourceNotes: "Should be out of range",
+          externalSourceNotes: "Should be out of range",
+        },
+      ],
     });
     const issues = checkCancelledEditions(event);
     expect(issues).toHaveLength(1);
@@ -68,7 +81,13 @@ describe("checkCancelledEditions", () => {
   it("flags a cancelled year inconsistent with annual cadence (SC18 biennial)", () => {
     const event = makeEvent({
       historicalEditions: held(["2010-01-01", "2012-01-01", "2016-01-01"]),
-      cancelledEditions: [{ year: 2014, sourceNotes: "Biennial event, not annual" }],
+      cancelledEditions: [
+        {
+          year: 2014,
+          internalSourceNotes: "Biennial event, not annual",
+          externalSourceNotes: "Biennial event, not annual",
+        },
+      ],
     });
     const issues = checkCancelledEditions(event);
     expect(issues).toHaveLength(1);
@@ -79,7 +98,13 @@ describe("checkCancelledEditions", () => {
   it("accepts a valid cancellation between consecutive annual editions", () => {
     const event = makeEvent({
       historicalEditions: held(["2010-01-01", "2011-01-01", "2013-01-01"]),
-      cancelledEditions: [{ year: 2012, sourceNotes: "Skipped, organiser sabbatical" }],
+      cancelledEditions: [
+        {
+          year: 2012,
+          internalSourceNotes: "Skipped, organiser sabbatical",
+          externalSourceNotes: "Skipped, organiser sabbatical",
+        },
+      ],
     });
     expect(checkCancelledEditions(event)).toEqual([]);
   });
@@ -88,8 +113,16 @@ describe("checkCancelledEditions", () => {
     const event = makeEvent({
       historicalEditions: held(["2018-01-01", "2019-01-01", "2022-01-01", "2023-01-01"]),
       cancelledEditions: [
-        { year: 2020, sourceNotes: "COVID" },
-        { year: 2021, sourceNotes: "COVID continued" },
+        {
+          year: 2020,
+          internalSourceNotes: "COVID",
+          externalSourceNotes: "COVID",
+        },
+        {
+          year: 2021,
+          internalSourceNotes: "COVID continued",
+          externalSourceNotes: "COVID continued",
+        },
       ],
     });
     expect(checkCancelledEditions(event)).toEqual([]);


### PR DESCRIPTION
## Summary

Replace the single `sourceNotes` field with two fields on every historical and cancelled edition:

- **`internalSourceNotes`** (required, minLength 1) — raw maintainer-facing provenance: FetLife event IDs, Wayback snapshot paths, commit hashes, ambiguity caveats. The reviewer's source-of-truth for trusting or correcting the record.
- **`externalSourceNotes`** (required, minLength 1) — clean human-readable summary shown on the website. One or two sentences a reader can understand without context. No raw IDs or internal URLs.

`EventPage.vue` renders `externalSourceNotes` in the historical-editions table and the prediction-provenance "Source notes" subsection. Internal notes never reach the website.

**Editorial pass:** every existing note preserved as `internalSourceNotes`; new clean `externalSourceNotes` hand-written for ~50 historical and 5 cancelled editions across all 13 events.

**Example contrast (RopeLinked Summer 2020 cancellation):**
- Internal: "COVID-era cancellation. Organiser numbering jumps from RopeLinked I (2019, FetLife sourceEventId=765184) to RopeLinked IV (2023, FetLife sourceEventId=1214654, attended by Andrea Ropes per andrearopes.com/en/about-me/...). The 4-year gap with no FetLife events or Wayback snapshots in 2020-2022 implies editions II and III were planned but did not run..."
- External: "COVID-era cancellation, validated by the organiser's edition-numbering pattern (I in 2019 jumps to IV in 2023)."

## Test Coverage

All paths exercised by the existing test suite. Test fixtures in 5 spec files updated to provide both fields. No new code paths introduced — this is a field rename + content split.

- `validate:data` passes (13 event files)
- `typecheck` passes
- `vitest` passes (8 files, 85/85)

## Pre-Landing Review

Ran `/review` against `origin/main`:
- 0 critical, 3 informational findings
- All 3 resolved before this PR:
  - Reverted incidental `package-lock.json` workspace-name swap
  - Tightened `internalSourceNotes` to `minLength: 1` on historical editions (matches the doc contract)
  - EURIX provenance phrasing repetition deferred (informational, pre-existing aggregation behavior)

## Plan Completion

No plan file. Driven by the user request: split the field, rewrite the externals editorially. Both delivered.

## TODOS

`TODOS.md` updated to reference `externalSourceNotes` in the mobile-friendly historical-editions row layout entry. No items closed.

## Documentation

In-tree: `CONTRIBUTING.md`, `docs/website-architecture-and-product-decisions.md`, `data/event-template.jsonc`, `.cursor/rules/contributing.mdc`, `.cursor/rules/data-format.mdc` all describe the two-field split and the editorial standard for each. README and CLAUDE.md don't reference source notes.

## Test plan

- [x] `npm run validate:data` passes (13 files)
- [x] `npm run typecheck` passes
- [x] `npm test` passes (85/85)
- [ ] Manual: visit an event detail page (e.g. EURIX Autumn) and verify the historical-editions table renders the new clean `externalSourceNotes` text; the messy raw notes never appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)